### PR TITLE
Update serialization input/output

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include bmds *.csv
+recursive-include bmds *.docx
 recursive-include bmds *.json
 recursive-include bmds/bin *
-recursive-include bmds/templates *

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -121,6 +121,9 @@ class BmdModel:
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
 
+    def get_param_names(self) -> List[str]:
+        raise NotImplementedError(...)
+
     def _add_bmr_lines(self, ax):
         res = self.results
         xdomain = ax.xaxis.get_view_interval()

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -116,7 +116,12 @@ class BmdModel:
         if self.dataset.dtype in DICHOTOMOUS_DTYPES:
             ax.set_ylim(-0.05, 1.05)
         ax.set_title(f"{self.dataset._get_dataset_name()}\n{self.name()}, ADD BMR")
-        ax.plot(self.results.dr_x, self.results.dr_y, label=self.name(), **plotting.LINE_FORMAT)
+        ax.plot(
+            self.results.plotting.dr_x,
+            self.results.plotting.dr_y,
+            label=self.name(),
+            **plotting.LINE_FORMAT,
+        )
         self._add_bmr_lines(ax)
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
@@ -130,9 +135,11 @@ class BmdModel:
         xrng = xdomain[1] - xdomain[0]
 
         if res.bmd > 0:
-            ax.plot([0, res.bmd], [res.bmd_y, res.bmd_y], **plotting.BMD_LINE_FORMAT)
             ax.plot(
-                [res.bmd, res.bmd], [0, res.bmd_y], **plotting.BMD_LINE_FORMAT,
+                [0, res.bmd], [res.plotting.bmd_y, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT
+            )
+            ax.plot(
+                [res.bmd, res.bmd], [0, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT,
             )
             ax.text(
                 res.bmd + xrng * 0.01,
@@ -145,7 +152,7 @@ class BmdModel:
             )
 
         if res.bmdl > 0:
-            ax.plot([res.bmdl, res.bmdl], [0, res.bmd_y], **plotting.BMD_LINE_FORMAT)
+            ax.plot([res.bmdl, res.bmdl], [0, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT)
             ax.text(
                 res.bmdl - xrng * 0.01,
                 0,

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -104,6 +104,9 @@ class BmdModel:
     def serialize(self) -> BaseModel:
         raise NotImplementedError("Requires abstract implementation")
 
+    def report(self) -> str:
+        raise NotImplementedError("Requires abstract implementation")
+
     def plot(self):
         """
         After model execution, print the dataset, curve-fit, BMD, and BMDL.
@@ -163,7 +166,7 @@ class BmdModel:
             )
 
     def to_dict(self) -> Dict:
-        return self.serialize.dict()
+        return self.serialize().dict()
 
 
 class BmdModelSchema(BaseModel):

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -1,6 +1,6 @@
 import ctypes
 import math
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 
@@ -191,6 +191,17 @@ class BmdModelContinuous(BmdModel):
             results=self.results,
         )
 
+    def get_param_names(self) -> List[str]:
+        names = list(self.bmd_model_class.params)
+        names.extend(self.get_variance_param_names())
+        return names
+
+    def get_variance_param_names(self):
+        if self.settings.disttype == DistType.normal_ncv:
+            return list(self.bmd_model_class.variance_params)
+        else:
+            return [self.bmd_model_class.variance_params[0]]
+
 
 class BmdModelContinuousSchema(BmdModelSchema):
     name: str
@@ -250,6 +261,11 @@ class Polynomial(BmdModelContinuous):
         for i in range(1, self.settings.degree + 1):
             val += params[i] * doses ** i
         return val
+
+    def get_param_names(self) -> List[str]:
+        names = [f"b{i}" for i in range(self.settings.degree + 1)]
+        names.extend(self.get_variance_param_names())
+        return names
 
 
 class Linear(Polynomial):

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -1,6 +1,6 @@
 import ctypes
 import math
-from typing import Optional, List
+from typing import List, Optional
 
 import numpy as np
 

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -1,12 +1,10 @@
 import ctypes
-import math
 from typing import List, Optional
 
 import numpy as np
 
 from ...datasets import ContinuousDatasets
 from ..constants import (
-    BMDS_BLANK_VALUE,
     ContinuousModel,
     ContinuousModelChoices,
     ContinuousModelIds,
@@ -14,13 +12,7 @@ from ..constants import (
     ModelPriors,
     PriorClass,
 )
-from ..types.common import residual_of_interest
-from ..types.continuous import (
-    ContinuousAnalysis,
-    ContinuousModelResult,
-    ContinuousModelSettings,
-    ContinuousResult,
-)
+from ..types.continuous import ContinuousAnalysis, ContinuousModelSettings, ContinuousResult
 from ..types.priors import get_continuous_prior
 from .base import BmdModel, BmdModelSchema, BmdsLibraryManager, InputModelSettings
 
@@ -136,6 +128,7 @@ class BmdModelContinuous(BmdModel):
             degree=self.settings.degree,
         )
         structs = inputs.to_c()
+        self.structs = structs
 
         # run the analysis
         dll = BmdsLibraryManager.get_dll(bmds_version="BMDS330", base_name="libDRBMD")
@@ -147,35 +140,8 @@ class BmdModelContinuous(BmdModel):
             ctypes.pointer(structs.gof),
             ctypes.c_bool(False),
         )
-
-        fit_results = ContinuousModelResult.from_c(structs.result)
-        dr_x = self.dataset.dose_linspace
-        critical_xs = np.array([structs.summary.bmdl, structs.summary.bmd, structs.summary.bmdu])
-        dr_y = self.dr_curve(dr_x, fit_results.params)
-        critical_ys = self.dr_curve(critical_xs, fit_results.params)
-        residuals = [d + 1 for d in self.dataset.doses]  # TODO - use real version
-        aic = (
-            structs.summary.aic if math.isfinite(structs.summary.aic) else BMDS_BLANK_VALUE
-        )  # TODO - after models fixed; remove this check?
-        result = ContinuousResult(
-            bmdl=structs.summary.bmdl,
-            bmd=structs.summary.bmd,
-            bmdu=structs.summary.bmdu,
-            aic=aic,
-            roi=residual_of_interest(structs.summary.bmd, self.dataset.doses, residuals),
-            bounded=[structs.summary.bounded[i] for i in range(inputs.num_params)],
-            fit=fit_results,
-            dr_x=dr_x.tolist(),
-            dr_y=dr_y.tolist(),
-            bmdl_y=critical_ys[0] if structs.summary.bmdl > 0 else BMDS_BLANK_VALUE,
-            bmd_y=critical_ys[1] if structs.summary.bmd > 0 else BMDS_BLANK_VALUE,
-            bmdu_y=critical_ys[2] if structs.summary.bmdu > 0 else BMDS_BLANK_VALUE,
-        )
-
-        self.structs = structs
-        self.results = result
-
-        return result
+        self.results = ContinuousResult.from_model(self)
+        return self.results
 
     def get_default_model_degree(self, dataset) -> int:
         return 0
@@ -201,6 +167,22 @@ class BmdModelContinuous(BmdModel):
             return list(self.bmd_model_class.variance_params)
         else:
             return [self.bmd_model_class.variance_params[0]]
+
+    def report(self) -> str:
+        name = f"╒════════════════════╕\n│ {self.name():18} │\n╘════════════════════╛"
+        if not self.has_results:
+            return "\n\n".join([name, "Execution was not completed."])
+
+        return "\n\n".join(
+            [
+                name,
+                f"Summary:\n{self.results.tbl()}",
+                f"Model Parameters:\n{self.results.parameters.tbl()}",
+                f"Goodness of Fit:\n{self.results.gof.tbl()}",
+                f"Analysis of Deviance:\n{self.results.deviance.tbl()}",
+                f"Tests of Interest:\n{self.results.tests.tbl()}",
+            ]
+        )
 
 
 class BmdModelContinuousSchema(BmdModelSchema):

--- a/bmds/bmds3/models/dichotomous.py
+++ b/bmds/bmds3/models/dichotomous.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 from scipy.stats import gamma, norm
@@ -109,6 +109,10 @@ class BmdModelDichotomous(BmdModel):
 
     def dr_curve(self, doses, params) -> np.ndarray:
         raise NotImplementedError()
+
+    def get_param_names(self) -> List[str]:
+        names = list(self.bmd_model_class.params)
+        return names
 
     def serialize(self) -> "BmdModelDichotomousSchema":
         return BmdModelDichotomousSchema(
@@ -288,6 +292,9 @@ class Multistage(BmdModelDichotomous):
 
     def get_default_priors(self) -> ModelPriors:
         return get_dichotomous_prior(self.bmd_model_class, PriorClass.frequentist_restricted)
+
+    def get_param_names(self) -> List[str]:
+        return [f"b{i}" for i in range(self.settings.degree + 1)]
 
 
 bmd_model_map = {

--- a/bmds/bmds3/models/dichotomous.py
+++ b/bmds/bmds3/models/dichotomous.py
@@ -90,6 +90,21 @@ class BmdModelDichotomous(BmdModel):
             results=self.results,
         )
 
+    def report(self) -> str:
+        name = f"╒════════════════════╕\n│ {self.name():18} │\n╘════════════════════╛"
+        if not self.has_results:
+            return "\n\n".join([name, "Execution was not completed."])
+
+        return "\n\n".join(
+            [
+                name,
+                f"Summary:\n{self.results.tbl()}",
+                f"Model Parameters:\n{self.results.parameters.tbl()}",
+                f"Goodness of Fit:\n{self.results.gof.tbl(self.dataset)}",
+                f"Analysis of Deviance:\n{self.results.deviance.tbl()}",
+            ]
+        )
+
 
 class BmdModelDichotomousSchema(BmdModelSchema):
     name: str

--- a/bmds/bmds3/models/dichotomous.py
+++ b/bmds/bmds3/models/dichotomous.py
@@ -1,26 +1,18 @@
 import ctypes
-from typing import Optional, List
+from typing import List, Optional
 
 import numpy as np
 from scipy.stats import gamma, norm
 
 from ...datasets import DichotomousDataset
 from ..constants import (
-    BMDS_BLANK_VALUE,
     DichotomousModel,
     DichotomousModelChoices,
     DichotomousModelIds,
     ModelPriors,
     PriorClass,
 )
-from ..types.common import residual_of_interest
-from ..types.dichotomous import (
-    DichotomousAnalysis,
-    DichotomousModelResult,
-    DichotomousModelSettings,
-    DichotomousPgofResult,
-    DichotomousResult,
-)
+from ..types.dichotomous import DichotomousAnalysis, DichotomousModelSettings, DichotomousResult
 from ..types.priors import get_dichotomous_prior
 from ..types.structs import DichotomousModelResultStruct
 from .base import BmdModel, BmdModelSchema, BmdsLibraryManager, InputModelSettings
@@ -61,6 +53,7 @@ class BmdModelDichotomous(BmdModel):
             burnin=self.settings.burnin,
         )
         structs = inputs.to_c()
+        self.structs = structs
 
         dll = BmdsLibraryManager.get_dll(bmds_version="BMDS330", base_name="libDRBMD")
         dll.runBMDSDichoAnalysis(
@@ -70,33 +63,8 @@ class BmdModelDichotomous(BmdModel):
             ctypes.pointer(structs.summary),
             ctypes.pointer(structs.aod),
         )
-
-        fit_results = DichotomousModelResult.from_c(structs.result, self)
-        gof_results = DichotomousPgofResult.from_c(structs.gof)
-        dr_x = self.dataset.dose_linspace
-        critical_xs = np.array([structs.summary.bmdl, structs.summary.bmd, structs.summary.bmdu])
-        dr_y = self.dr_curve(dr_x, fit_results.params)
-        critical_ys = self.dr_curve(critical_xs, fit_results.params)
-        result = DichotomousResult(
-            bmdl=structs.summary.bmdl,
-            bmd=structs.summary.bmd,
-            bmdu=structs.summary.bmdu,
-            aic=structs.summary.aic,
-            roi=residual_of_interest(structs.summary.bmd, self.dataset.doses, gof_results.residual),
-            bounded=[structs.summary.bounded[i] for i in range(inputs.num_params)],
-            fit=fit_results,
-            gof=gof_results,
-            dr_x=dr_x.tolist(),
-            dr_y=dr_y.tolist(),
-            bmdl_y=critical_ys[0] if structs.summary.bmdl > 0 else BMDS_BLANK_VALUE,
-            bmd_y=critical_ys[1] if structs.summary.bmd > 0 else BMDS_BLANK_VALUE,
-            bmdu_y=critical_ys[2] if structs.summary.bmdu > 0 else BMDS_BLANK_VALUE,
-        )
-
-        self.structs = structs
-        self.results = result
-
-        return result
+        self.results = DichotomousResult.from_model(self)
+        return self.results
 
     def get_default_model_degree(self, dataset) -> int:
         return self.bmd_model_class.num_params - 1

--- a/bmds/bmds3/recommender/checks.py
+++ b/bmds/bmds3/recommender/checks.py
@@ -90,7 +90,7 @@ class AicExists(ExistenceCheck):
 
     @classmethod
     def get_value(cls, dataset, model) -> Optional[Number]:
-        return model.results.aic
+        return model.results.fit.aic
 
 
 class BmdExists(ExistenceCheck):
@@ -106,7 +106,7 @@ class RoiExists(ExistenceCheck):
 
     @classmethod
     def get_value(cls, dataset, model) -> Optional[Number]:
-        return model.results.roi
+        return model.results.gof.roi
 
 
 class BmdlExists(ExistenceCheck):
@@ -187,7 +187,7 @@ class LargeRoi(ShouldBeLessThan):
 
     @classmethod
     def get_value(cls, dataset, model) -> Optional[Number]:
-        return abs(model.results.roi)
+        return abs(model.results.gof.roi)
 
 
 class BmdBmdlRatio(ShouldBeLessThan):

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import numpy as np
 import pandas as pd
 from pydantic import BaseModel, validator
 
@@ -188,8 +189,15 @@ class Recommender:
         Returns a list of models which have the minimum target field value
         for a given field name (AIC or BMDL).
         """
-        target_value = min([getattr(model.results, field) for model in models])
-        return [model for model in models if getattr(model.results, field) == target_value]
+        if field == "aic":
+            values = np.array([getattr(model.results.fit, field) for model in models])
+        elif field == "bmdl":
+            values = np.array([getattr(model.results, field) for model in models])
+        else:
+            raise ValueError(f"Unknown target field: {field}")
+
+        matches = np.where(values == values.min())[0].tolist()
+        return [models[i] for i in matches]
 
     def _get_parsimonious_model(self, models: List[BmdModel]) -> BmdModel:
         """

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -197,7 +197,7 @@ class Recommender:
         parsimonious model is defined as the model with the fewest number of
         parameters.
         """
-        params = [len(model.results.fit.params) for model in models]
+        params = [len(model.results.parameters.values) for model in models]
         idx = params.index(min(params))
         return models[idx]
 

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -139,6 +139,8 @@ def write_models(report: Report, session, header_level: int):
             "This is just an example of what can be done...", styles.tbl_body
         )
         tbl = tabulate.tabulate(
-            [model.results.fit.params], headers=model.bmd_model_class.params, tablefmt="fancy_grid",
+            [model.results.parameters.values],
+            headers=model.bmd_model_class.params,
+            tablefmt="fancy_grid",
         )
         report.document.add_paragraph(tbl, styles.outfile)

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -100,7 +100,7 @@ def write_summary_table(report: Report, session, header_level: int):
         idx = i + 2
         write_cell(tbl.cell(idx, 0), model.name(), body)
         write_cell(tbl.cell(idx, 1), "-999", body)
-        write_cell(tbl.cell(idx, 2), model.results.aic, body)
+        write_cell(tbl.cell(idx, 2), model.results.fit.aic, body)
         write_cell(tbl.cell(idx, 3), model.results.bmd, body)
         write_cell(tbl.cell(idx, 4), model.results.bmdl, body)
 

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -182,7 +182,7 @@ class BmdsSession:
                     model.results.bmd,
                     model.results.bmdl,
                     model.results.bmdu,
-                    model.results.aic,
+                    model.results.fit.aic,
                     list_to_str(model.results.parameters.values),
                 ]
             )

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -183,7 +183,7 @@ class BmdsSession:
                     model.results.bmdl,
                     model.results.bmdu,
                     model.results.aic,
-                    list_to_str(model.results.fit.params),
+                    list_to_str(model.results.parameters.values),
                 ]
             )
         df = pd.DataFrame(data=model_rows, columns=model_row_names)

--- a/bmds/bmds3/types/common.py
+++ b/bmds/bmds3/types/common.py
@@ -1,6 +1,7 @@
 from typing import Any, List
 
 import numpy as np
+import tabulate
 
 from ..constants import BMDS_BLANK_VALUE
 
@@ -13,6 +14,10 @@ NUM_TESTS_OF_INTEREST = 4
 
 def list_t_c(list: List[Any], ctype):
     return (ctype * len(list))(*list)
+
+
+def pretty_table(data, headers):
+    return tabulate.tabulate(data, headers=headers, tablefmt="fancy_grid")
 
 
 def residual_of_interest(bmd: float, doses: List[float], residuals: List[float]) -> float:

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -92,6 +92,7 @@ class DichotomousModelResultStruct(ctypes.Structure):
 
 
 class DichotomousPgofResultStruct(ctypes.Structure):
+
     _fields_ = [
         ("n", ctypes.c_int),  # total number of observations obs/n
         ("expected", ctypes.POINTER(ctypes.c_double)),
@@ -122,6 +123,7 @@ class DichotomousPgofResultStruct(ctypes.Structure):
 
 
 class DichotomousAodStruct(ctypes.Structure):
+    # Dichotomous Analysis of Deviance Struct
 
     _fields_ = [
         ("fullLL", ctypes.c_double),
@@ -174,6 +176,7 @@ class DichotomousBmdsResultsStruct(ctypes.Structure):
             bmdl: {self.bmdl}
             bmdu: {self.bmdu}
             aic: {self.aic}
+            chisq: {self.chisq}
             bounded: {self.bounded[:self.n]}
             """
         )
@@ -185,6 +188,7 @@ class DichotomousBmdsResultsStruct(ctypes.Structure):
         self.bmdl = constants.BMDS_BLANK_VALUE
         self.bmdu = constants.BMDS_BLANK_VALUE
         self.aic = constants.BMDS_BLANK_VALUE
+        self.chisq = constants.BMDS_BLANK_VALUE
         self.np_bounded = np.zeros(self.n, dtype=np.bool_)
         self.bounded = np.ctypeslib.as_ctypes(self.np_bounded)
 
@@ -193,8 +197,8 @@ class DichotomousStructs(NamedTuple):
     analysis: DichotomousAnalysisStruct
     result: DichotomousModelResultStruct
     gof: DichotomousPgofResultStruct
-    summary: DichotomousBmdsResultsStruct
     aod: DichotomousAodStruct
+    summary: DichotomousBmdsResultsStruct
 
     def __str__(self):
         return dedent(

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -494,7 +494,8 @@ class ContinuousAodStruct(ctypes.Structure):
         self.nParms = np.ctypeslib.as_ctypes(self.np_nParms)
         self.np_AIC = np.zeros(5, dtype=np.float64)
         self.AIC = np.ctypeslib.as_ctypes(self.np_AIC)
-        self.TOI = ctypes.pointer(ContinuousToiStruct())
+        self.toi_struct = ContinuousToiStruct()
+        self.TOI = ctypes.pointer(self.toi_struct)
 
 
 class ContinuousBmdsResultsStruct(ctypes.Structure):

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -453,15 +453,6 @@ class ContinuousToiStruct(ctypes.Structure):
         ("pVal", ctypes.POINTER(ctypes.c_double)),
     ]
 
-    def __str__(self) -> str:
-        return dedent(
-            f"""
-            llRatio: {self.llRatio[:4]}
-            DF: {self.DF[:4]}
-            pVal: {self.pVal[:4]}
-            """
-        )
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.np_llRatio = np.zeros(4, dtype=np.float64)
@@ -482,16 +473,17 @@ class ContinuousAodStruct(ctypes.Structure):
     ]
 
     def __str__(self) -> str:
-        return (
-            dedent(
-                f"""
-                LL: {self.LL[:5]}
-                nParms: {self.nParms[:5]}
-                AIC: {self.AIC[:5]}
-                addConst: {self.addConst}
-                """
-            )
-            + str(self.TOI[0])
+        toi = self.TOI[0]
+        return dedent(
+            f"""
+            LL: {self.LL[:5]}
+            nParms: {self.nParms[:5]}
+            AIC: {self.AIC[:5]}
+            addConst: {self.addConst}
+            llRatio: {toi.llRatio[:4]}
+            DF: {toi.DF[:4]}
+            pVal: {toi.pVal[:4]}
+            """
         )
 
     def __init__(self, *args, **kwargs):

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -136,8 +136,8 @@ class DichotomousAodStruct(ctypes.Structure):
         ("devRed", ctypes.c_double),
         ("dfFit", ctypes.c_int),
         ("dfRed", ctypes.c_int),
-        ("pvFit", ctypes.c_int),
-        ("pvRed", ctypes.c_int),
+        ("pvFit", ctypes.c_double),
+        ("pvRed", ctypes.c_double),
     ]
 
     def __str__(self) -> str:

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -522,6 +522,7 @@ class ContinuousBmdsResultsStruct(ctypes.Structure):
         self.bmdl = constants.BMDS_BLANK_VALUE
         self.bmdu = constants.BMDS_BLANK_VALUE
         self.aic = constants.BMDS_BLANK_VALUE
+        self.chisq = constants.BMDS_BLANK_VALUE
         self.np_bounded = np.zeros(self.n, dtype=np.bool_)
         self.bounded = np.ctypeslib.as_ctypes(self.np_bounded)
 
@@ -532,6 +533,7 @@ class ContinuousBmdsResultsStruct(ctypes.Structure):
             bmdl: {self.bmdl}
             bmdu: {self.bmdu}
             aic: {self.aic}
+            chisq: {self.chisq}
             bounded: {self.bounded[:self.n]}
             """
         )

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -54,6 +54,31 @@ class TestPriorOverrides:
         ...
 
 
+class TestBmdModelContinuous:
+    def test_get_param_names(self, contds):
+        # test normal model case
+        for m in [
+            continuous.Power(dataset=contds),
+            continuous.Power(dataset=contds, settings=dict(disttype=DistType.normal)),
+            continuous.Power(dataset=contds, settings=dict(disttype=DistType.log_normal)),
+        ]:
+            assert m.get_param_names() == ["g", "v", "n", "rho"]
+        m = continuous.Power(dataset=contds, settings=dict(disttype=DistType.normal_ncv))
+        assert m.get_param_names() == ["g", "v", "n", "rho", "alpha"]
+
+        # test polynomial
+        model = continuous.Linear(dataset=contds)
+        assert model.get_param_names() == ["b0", "b1", "rho"]
+        model = continuous.Polynomial(dataset=contds)
+        assert model.get_param_names() == ["b0", "b1", "b2", "rho"]
+        model = continuous.Polynomial(dataset=contds, settings=dict(degree=3))
+        assert model.get_param_names() == ["b0", "b1", "b2", "b3", "rho"]
+        model = continuous.Polynomial(
+            dataset=contds, settings=dict(degree=3, disttype=DistType.normal_ncv)
+        )
+        assert model.get_param_names() == ["b0", "b1", "b2", "b3", "rho", "alpha"]
+
+
 @pytest.mark.skipif(not should_run, reason=skip_reason)
 def test_bmds3_increasing(contds):
     """

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -78,6 +78,18 @@ class TestBmdModelContinuous:
         )
         assert model.get_param_names() == ["b0", "b1", "b2", "b3", "rho", "alpha"]
 
+    @pytest.mark.skipif(not should_run, reason=skip_reason)
+    def test_report(self, contds):
+        model = continuous.Hill(dataset=contds)
+        text = model.report()
+        assert "Hill" in text
+        assert "Execution was not completed." in text
+
+        model.execute()
+        text = model.report()
+        assert "Hill" in text
+        assert "Analysis of Deviance" in text
+
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
 def test_bmds3_increasing(contds):
@@ -96,10 +108,10 @@ def test_bmds3_increasing(contds):
         result = Model(contds).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.aic, 1)})"
+        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
         # print(res)
         assert pytest.approx(bmd_values, abs=1.0) == actual, Model.__name__
-        assert pytest.approx(aic, abs=5.0) == result.aic, Model.__name__
+        assert pytest.approx(aic, abs=5.0) == result.fit.aic, Model.__name__
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
@@ -116,10 +128,10 @@ def test_bmds3_decreasing(negative_contds):
         result = Model(negative_contds).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.aic, 1)})"
+        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
         # print(res)
         assert pytest.approx(bmd_values, abs=1.0) == actual, Model.__name__
-        assert pytest.approx(aic, abs=5.0) == result.aic, Model.__name__
+        assert pytest.approx(aic, abs=5.0) == result.fit.aic, Model.__name__
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
@@ -128,12 +140,12 @@ def test_bmds3_variance(contds):
     result = model.execute()
     assert model.settings.disttype is DistType.normal
     assert pytest.approx(result.bmd, abs=0.1) == 26.007
-    assert len(result.fit.params) == 4
+    assert len(result.parameters.values) == 4
 
     model = continuous.Power(contds, dict(disttype=DistType.normal_ncv))
     result = model.execute()
     assert model.settings.disttype is DistType.normal_ncv
-    assert len(result.fit.params) == 5
+    assert len(result.parameters.values) == 5
     assert pytest.approx(result.bmd, abs=1.0) == 13.676
 
     # TODO -fix - currently segfault
@@ -141,7 +153,7 @@ def test_bmds3_variance(contds):
     # result = model.execute()
     # assert model.settings.disttype is DistType.log_normal
     # assert pytest.approx(result.bmd, abs=0.1) == 123
-    # assert len(result.fit.params) == 4
+    # assert len(result.parameters.values) == 4
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
@@ -161,10 +173,10 @@ def test_bmds3_continuous_polynomial(contds):
         result = continuous.Polynomial(contds, settings).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # res = f"({degree}, {np.round(actual, 3).tolist()}, {round(result.aic, 1)})"
+        # res = f"({degree}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
         # print(res)
         assert pytest.approx(actual, abs=1.0) == bmd_values, degree
-        assert pytest.approx(aic, abs=5.0) == result.aic, degree
+        assert pytest.approx(aic, abs=5.0) == result.fit.aic, degree
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)

--- a/tests/bmds3/test_bmds3_dich_models.py
+++ b/tests/bmds3/test_bmds3_dich_models.py
@@ -31,6 +31,17 @@ class TestBmdModelDichotomous:
         model = dichotomous.Multistage(dataset=dichds, settings=dict(degree=3))
         assert model.get_param_names() == ["b0", "b1", "b2", "b3"]
 
+    def test_report(self, dichds):
+        model = dichotomous.Gamma(dataset=dichds)
+        text = model.report()
+        assert "Gamma" in text
+        assert "Execution was not completed." in text
+
+        model.execute()
+        text = model.report()
+        assert "Gamma" in text
+        assert "Analysis of Deviance" in text
+
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
 def test_bmds3_dichotomous_models(dichds):
@@ -50,10 +61,10 @@ def test_bmds3_dichotomous_models(dichds):
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
         # print(
-        #     f"(dichotomous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.aic, 1)})"
+        #     f"(dichotomous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
         # )
         assert pytest.approx(bmd_values, abs=0.1) == actual
-        assert pytest.approx(aic, abs=3.0) == result.aic
+        assert pytest.approx(aic, abs=3.0) == result.fit.aic
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
@@ -74,9 +85,9 @@ def test_bmds3_dichotomous_multistage(dichds):
         result = model.execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for modifying values
-        # print(f"({degree}, {np.round(actual, 3).tolist()}, {round(result.aic, 1)})")
+        # print(f"({degree}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})")
         assert pytest.approx(bmd_values, abs=0.1) == actual
-        assert pytest.approx(aic, abs=3.0) == result.aic
+        assert pytest.approx(aic, abs=3.0) == result.fit.aic
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)

--- a/tests/bmds3/test_bmds3_dich_models.py
+++ b/tests/bmds3/test_bmds3_dich_models.py
@@ -19,6 +19,19 @@ def dichds():
     )
 
 
+class TestBmdModelDichotomous:
+    def test_get_param_names(self, dichds):
+        # test normal model case
+        model = dichotomous.Gamma(dataset=dichds)
+        assert model.get_param_names() == ["g", "a", "b"]
+
+        # test multistage
+        model = dichotomous.Multistage(dataset=dichds)
+        assert model.get_param_names() == ["b0", "b1", "b2"]
+        model = dichotomous.Multistage(dataset=dichds, settings=dict(degree=3))
+        assert model.get_param_names() == ["b0", "b1", "b2", "b3"]
+
+
 @pytest.mark.skipif(not should_run, reason=skip_reason)
 def test_bmds3_dichotomous_models(dichds):
     # compare bmd, bmdl, bmdu, aic values

--- a/tests/bmds3/test_bmds3_dich_models.py
+++ b/tests/bmds3/test_bmds3_dich_models.py
@@ -31,6 +31,7 @@ class TestBmdModelDichotomous:
         model = dichotomous.Multistage(dataset=dichds, settings=dict(degree=3))
         assert model.get_param_names() == ["b0", "b1", "b2", "b3"]
 
+    @pytest.mark.skipif(not should_run, reason=skip_reason)
     def test_report(self, dichds):
         model = dichotomous.Gamma(dataset=dichds)
         text = model.report()

--- a/tests/bmds3/test_bmds3_recommender.py
+++ b/tests/bmds3/test_bmds3_recommender.py
@@ -58,7 +58,7 @@ class TestSessionRecommender:
         # model recommended and selection is accurate
         assert session.recommender.results.recommended_model_index == 1
         assert session.recommender.results.recommended_model_variable == "aic"
-        assert session.models[1].results.aic < session.models[0].results.aic
+        assert session.models[1].results.fit.aic < session.models[0].results.fit.aic
 
     def test_apply_logic_cont(self, cdataset):
         session = bmds.session.Bmds330(dataset=cdataset)
@@ -83,14 +83,14 @@ class TestChecks:
 
         # good values
         for value in [-1, 0, 1]:
-            model.results.aic = value
+            model.results.fit.aic = value
             resp = AicExists.check(dataset, model, settings)
             assert resp.logic_bin == LogicBin.NO_CHANGE
             assert resp.message == ""
 
         # bad values
         for value in [None, BMDS_BLANK_VALUE]:
-            model.results.aic = value
+            model.results.fit.aic = value
             resp = AicExists.check(dataset, model, settings)
             assert resp.logic_bin == LogicBin.FAILURE
             assert resp.message == "AIC does not exist"
@@ -123,14 +123,14 @@ class TestChecks:
 
         # good values
         for value in [-2, 0, 2]:
-            model.results.roi = value
+            model.results.gof.roi = value
             resp = LargeRoi.check(dataset, model, settings)
             assert resp.logic_bin == LogicBin.NO_CHANGE
             assert resp.message == ""
 
         # bad values
         for value in [-2.1, 2.1]:
-            model.results.roi = value
+            model.results.gof.roi = value
             resp = LargeRoi.check(dataset, model, settings)
             assert resp.logic_bin == LogicBin.FAILURE
             assert resp.message == "Abs(Residual of interest) is greater than threshold (2.1 > 2.0)"


### PR DESCRIPTION

- refactor how outputs are serialized; not as tightly coupled to underlying C structures
- (bug) add docx file to python package manifest
- (bug) fix pvFit data type from int to double
- build `report()` method for all models for a text representation
- added `get_param_names` to save variable names for models