### PR TITLE
np.nan_to_num for model outputs

### DIFF
--- a/bmds/bmds3/types/common.py
+++ b/bmds/bmds3/types/common.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List
+import math
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import tabulate
@@ -10,6 +11,10 @@ CDF_TABLE_SIZE = 99
 MY_MAX_PARMS = 16
 NUM_LIKELIHOODS_OF_INTEREST = 5
 NUM_TESTS_OF_INTEREST = 4
+
+
+def inf_to_none(value: float) -> Optional[float]:
+    return value if math.isfinite(value) else None
 
 
 def list_t_c(list: List[Any], ctype):

--- a/bmds/bmds3/types/common.py
+++ b/bmds/bmds3/types/common.py
@@ -1,5 +1,4 @@
-import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import numpy as np
 import tabulate
@@ -11,10 +10,6 @@ CDF_TABLE_SIZE = 99
 MY_MAX_PARMS = 16
 NUM_LIKELIHOODS_OF_INTEREST = 5
 NUM_TESTS_OF_INTEREST = 4
-
-
-def inf_to_none(value: float) -> Optional[float]:
-    return value if math.isfinite(value) else None
 
 
 def list_t_c(list: List[Any], ctype):

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -262,9 +262,9 @@ class ContinuousDeviance(BaseModel):
         aod = model.structs.aod
         return cls(
             names=["A1", "A2", "A3", "fitted", "reduced"],
-            loglikelihoods=aod.np_LL.tolist(),
+            loglikelihoods=np.nan_to_num(aod.np_LL).tolist(),  # TODO - remove np.nan_to_num
             num_params=aod.np_nParms.tolist(),
-            aics=aod.np_AIC.tolist(),
+            aics=np.nan_to_num(aod.np_AIC).tolist(),  # TODO - remove np.nan_to_num
         )
 
     def tbl(self) -> str:
@@ -288,9 +288,9 @@ class ContinuousTests(BaseModel):
         tests = model.structs.aod.toi_struct
         return cls(
             names=["p_test1", "p_test2", "p_test3", "p_test4"],
-            ll_ratios=tests.np_llRatio.tolist(),
-            dfs=tests.np_DF.tolist(),
-            p_values=tests.np_pVal.tolist(),
+            ll_ratios=np.nan_to_num(tests.np_llRatio).tolist(),  # TODO - remove np.nan_to_num
+            dfs=np.nan_to_num(tests.np_DF).tolist(),  # TODO - remove np.nan_to_num
+            p_values=np.nan_to_num(tests.np_pVal).tolist(),  # TODO - remove np.nan_to_num
         )
 
     def tbl(self) -> str:

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -10,7 +10,7 @@ from bmds.datasets.continuous import ContinuousDatasets
 
 from ...constants import BOOL_ICON, Dtype
 from .. import constants
-from .common import NumpyFloatArray, inf_to_none, list_t_c, pretty_table, residual_of_interest
+from .common import NumpyFloatArray, list_t_c, pretty_table, residual_of_interest
 from .priors import ModelPriors
 from .structs import (
     BmdsResultsStruct,
@@ -151,7 +151,7 @@ class ContinuousModelResult(BaseModel):
             dist=result.dist,
             loglikelihood=result.max,
             aic=summary.aic,
-            bic_equiv=inf_to_none(summary.BIC_equiv),
+            bic_equiv=np.nan_to_num(summary.BIC_equiv),  # TODO remove?
             chisq=summary.chisq,
             model_df=result.model_df,
             total_df=result.total_df,

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -10,7 +10,7 @@ from bmds.datasets.continuous import ContinuousDatasets
 
 from ...constants import BOOL_ICON, Dtype
 from .. import constants
-from .common import NumpyFloatArray, list_t_c, pretty_table, residual_of_interest
+from .common import NumpyFloatArray, inf_to_none, list_t_c, pretty_table, residual_of_interest
 from .priors import ModelPriors
 from .structs import (
     BmdsResultsStruct,
@@ -133,7 +133,7 @@ class ContinuousModelResult(BaseModel):
     dist: int
     loglikelihood: float
     aic: float
-    bic_equiv: float
+    bic_equiv: Optional[float]
     chisq: float
     model_df: float
     total_df: float
@@ -151,7 +151,7 @@ class ContinuousModelResult(BaseModel):
             dist=result.dist,
             loglikelihood=result.max,
             aic=summary.aic,
-            bic_equiv=summary.BIC_equiv,
+            bic_equiv=inf_to_none(summary.BIC_equiv),
             chisq=summary.chisq,
             model_df=result.model_df,
             total_df=result.total_df,

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -133,7 +133,7 @@ class ContinuousModelResult(BaseModel):
     dist: int
     loglikelihood: float
     aic: float
-    bic_equiv: Optional[float]
+    bic_equiv: float
     chisq: float
     model_df: float
     total_df: float

--- a/bmds/bmds3/types/dichotomous.py
+++ b/bmds/bmds3/types/dichotomous.py
@@ -10,7 +10,7 @@ from bmds.bmds3.constants import DichotomousModelChoices, ModelPriors
 from ...constants import BOOL_ICON
 from ...datasets import DichotomousDataset
 from .. import constants
-from .common import NumpyFloatArray, inf_to_none, list_t_c, pretty_table, residual_of_interest
+from .common import NumpyFloatArray, list_t_c, pretty_table, residual_of_interest
 from .structs import (
     BmdsResultsStruct,
     DichotomousAnalysisStruct,
@@ -121,7 +121,7 @@ class DichotomousModelResult(BaseModel):
         return DichotomousModelResult(
             loglikelihood=result.max,
             aic=summary.aic,
-            bic_equiv=inf_to_none(summary.BIC_equiv),
+            bic_equiv=np.nan_to_num(summary.BIC_equiv),  # TODO remove?
             chisq=summary.chisq,
             model_df=result.model_df,
             total_df=result.total_df,

--- a/bmds/bmds3/types/dichotomous.py
+++ b/bmds/bmds3/types/dichotomous.py
@@ -10,7 +10,7 @@ from bmds.bmds3.constants import DichotomousModelChoices, ModelPriors
 from ...constants import BOOL_ICON
 from ...datasets import DichotomousDataset
 from .. import constants
-from .common import NumpyFloatArray, list_t_c, pretty_table, residual_of_interest
+from .common import NumpyFloatArray, inf_to_none, list_t_c, pretty_table, residual_of_interest
 from .structs import (
     BmdsResultsStruct,
     DichotomousAnalysisStruct,
@@ -103,7 +103,7 @@ class DichotomousAnalysis(BaseModel):
 class DichotomousModelResult(BaseModel):
     loglikelihood: float
     aic: float
-    bic_equiv: float
+    bic_equiv: Optional[float]
     chisq: float
     model_df: float
     total_df: float
@@ -121,7 +121,7 @@ class DichotomousModelResult(BaseModel):
         return DichotomousModelResult(
             loglikelihood=result.max,
             aic=summary.aic,
-            bic_equiv=summary.BIC_equiv,
+            bic_equiv=inf_to_none(summary.BIC_equiv),
             chisq=summary.chisq,
             model_df=result.model_df,
             total_df=result.total_df,
@@ -192,7 +192,7 @@ class DichotomousParameters(BaseModel):
             names=model.get_param_names(),
             values=result.np_parms,
             bounded=summary.np_bounded,
-            se=summary.np_stdErr,
+            se=np.nan_to_num(summary.np_stdErr),  # TODO - is this required?; se can be NaN
             lower_ci=summary.np_lowerConf,
             upper_ci=summary.np_upperConf,
             cov=result.np_cov.reshape(result.nparms, result.nparms),

--- a/bmds/bmds3/types/dichotomous.py
+++ b/bmds/bmds3/types/dichotomous.py
@@ -103,7 +103,7 @@ class DichotomousAnalysis(BaseModel):
 class DichotomousModelResult(BaseModel):
     loglikelihood: float
     aic: float
-    bic_equiv: Optional[float]
+    bic_equiv: float
     chisq: float
     model_df: float
     total_df: float


### PR DESCRIPTION
In some cases shared object return nan or inf; these are not json serializable. Use nan_to_num to cast -inf/inf to small/big floats, and nan -> 0.