### PR TITLE
Updated model averaging

### DIFF
--- a/bmds/bmds3/constants.py
+++ b/bmds/bmds3/constants.py
@@ -167,6 +167,12 @@ class Prior(BaseModel):
     min_value: float
     max_value: float
 
+    def tbl_str_hdr(self) -> str:
+        return "| param | type       |    initial |      stdev |        min |        max |"
+
+    def tbl_str(self) -> str:
+        return f"| {self.name:5} | {self.type.name:10} | {self.initial_value:10.3g} | {self.stdev:10.3g} | {self.min_value:10.3g} | {self.max_value:10.3g} |"
+
     def numeric_list(self) -> List[float]:
         return list(self.dict(exclude={"name"}).values())
 
@@ -193,6 +199,24 @@ class ModelPriors(BaseModel):
     prior_class: PriorClass  # if this is a predefined model class
     priors: List[Prior]  # priors for main model
     variance_priors: Optional[List[Prior]]  # priors for variance model (continuous-only)
+
+    def __str__(self):
+        ps = [self.priors[0].tbl_str_hdr()]
+        ps.extend([p.tbl_str() for p in self.priors])
+        ps = "\n".join(ps)
+
+        vps = ["<none>"]
+        if self.variance_priors:
+            vps = [self.variance_priors[0].tbl_str_hdr()]
+            vps.extend([p.tbl_str() for p in self.variance_priors])
+        vps = "\n".join(vps)
+
+        return f"""
+{self.prior_class.name} <{self.prior_class.value}>
+Priors:
+{ps}
+Variance priors:
+{vps}"""
 
     def to_table(self):
         raise NotImplementedError()

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -90,7 +90,7 @@ class BmdModel:
 
     @property
     def has_results(self) -> bool:
-        return self.results is not None
+        return self.results is not None and self.results.has_completed is True
 
     def get_model_settings(self, dataset: DatasetType, settings: InputModelSettings) -> BaseModel:
         raise NotImplementedError("Requires abstract implementation")

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -36,8 +36,11 @@ def get_default_priors(
 
     model_priors = get_continuous_prior(model_class, prior_class)
 
-    # exp5
-    if model_class == ContinuousModelChoices.c_exp_m5.value:
+    # exp3/exp5
+    if model_class in [
+        ContinuousModelChoices.c_exp_m3.value,
+        ContinuousModelChoices.c_exp_m5.value,
+    ]:
         if settings.is_increasing is True:
             model_priors.priors[2].min_value = 0
             model_priors.priors[2].max_value = 18

--- a/bmds/bmds3/models/ma.py
+++ b/bmds/bmds3/models/ma.py
@@ -4,7 +4,7 @@ from typing import List
 from ...datasets import DichotomousDataset
 from ..types.dichotomous import DichotomousModelSettings
 from ..types.ma import DichotomousModelAverageResult
-from ..types.structs import DichotomousMAAnalysisStruct, DichotomousMAResultStruct
+from ..types.structs import DichotomousMAAnalysisStruct, MAResultsStruct, DichotomousMAResultStruct
 from .base import BmdModelAveraging, BmdModelAveragingSchema, BmdsLibraryManager, InputModelSettings
 
 
@@ -28,18 +28,21 @@ class BmdModelAveragingDichotomous(BmdModelAveraging):
             models=[model.structs.analysis for model in self.models]
         )
         ma_inputs_struct = self.models[0].structs.analysis
-        ma_result_struct = DichotomousMAResultStruct.from_python(
+        dich_ma_result_struct = DichotomousMAResultStruct.from_python(
             models=[model.structs.result for model in self.models]
         )
+        ma_result_struct = MAResultsStruct(n_models=len(self.models))
 
-        dll.estimate_ma_laplace_dicho(
+        dll.runBMDSDichoMA(
             ctypes.pointer(ma_analysis_struct),
             ctypes.pointer(ma_inputs_struct),
+            ctypes.pointer(dich_ma_result_struct),
             ctypes.pointer(ma_result_struct),
         )
 
+        model_results = [model.results for model in self.models]
         return DichotomousModelAverageResult.from_execution(
-            ma_analysis_struct, ma_result_struct, self.models
+            ma_analysis_struct, dich_ma_result_struct, model_results, ma_result_struct
         )
 
     def serialize(self, session) -> "BmdModelAveragingDichotomousSchema":

--- a/bmds/bmds3/types/ma.py
+++ b/bmds/bmds3/types/ma.py
@@ -19,8 +19,7 @@ class DichotomousModelAverageResult(ModelAverageResult):
     bmd: float
     bmdl: float
     bmdu: float
-    bmd_quantile: NumpyFloatArray
-    bmd_value: NumpyFloatArray
+    bmd_dist: NumpyFloatArray
     priors: NumpyFloatArray
     posteriors: NumpyFloatArray
     dr_x: NumpyFloatArray
@@ -44,8 +43,7 @@ class DichotomousModelAverageResult(ModelAverageResult):
             bmdl=structs.result.bmdl_ma,
             bmd=structs.result.bmd_ma,
             bmdu=structs.result.bmdu_ma,
-            bmd_quantile=arr.T[0, :],
-            bmd_value=arr.T[1, :],
+            bmd_dist=arr.T,
             priors=priors,
             posteriors=posteriors,
             dr_x=dr_x,

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -293,6 +293,19 @@ class DichotomousMAAnalysisStruct(ctypes.Structure):
         self.models = np.ctypeslib.as_ctypes(self.np_models)
         self.modelPriors = np.ctypeslib.as_ctypes(self.np_modelPriors)
 
+    def __str__(self) -> str:
+        return dedent(
+            f"""
+            nmodels: {self.nmodels}
+            priors: {self.priors}
+            nparms: {self.np_nparms}
+            actual_parms: {self.np_actual_parms}
+            prior_cols: {self.np_prior_cols}
+            models: {self.np_models}
+            modelPriors: {self.np_modelPriors}
+            """
+        )
+
 
 class DichotomousMAResultStruct(ctypes.Structure):
     _fields_ = [

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -312,6 +312,38 @@ class DichotomousMAResultStruct(ctypes.Structure):
         )
 
 
+class MAResultsStruct(ctypes.Structure):
+    _fields_ = [
+        ("bmd_ma", ctypes.c_double),
+        ("bmdl_ma", ctypes.c_double),
+        ("bmdu_ma", ctypes.c_double),
+        ("bmd", ctypes.POINTER(ctypes.c_double)),
+        ("bmdl", ctypes.POINTER(ctypes.c_double)),
+        ("bmdu", ctypes.POINTER(ctypes.c_double)),
+    ]
+
+    def __str__(self) -> str:
+        return dedent(
+            f"""
+            bmd_ma: {self.bmd_ma}
+            bmdl_ma: {self.bmdl_ma}
+            bmdu_ma: {self.bmdu_ma}
+            bmd: {self.np_bmd.tolist()}
+            bmdl: {self.np_bmdl.tolist()}
+            bmdu: {self.np_bmdu.tolist()}
+            """
+        )
+
+    def __init__(self, n_models: int):
+        super().__init__()
+        self.np_bmd = np.zeros(n_models, dtype=np.float64)
+        self.np_bmdl = np.zeros(n_models, dtype=np.float64)
+        self.np_bmdu = np.zeros(n_models, dtype=np.float64)
+        self.bmd = np.ctypeslib.as_ctypes(self.np_bmd)
+        self.bmdl = np.ctypeslib.as_ctypes(self.np_bmdl)
+        self.bmdu = np.ctypeslib.as_ctypes(self.np_bmdu)
+
+
 # CONTINUOUS MODELS
 # -----------------
 

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -31,6 +31,7 @@ class DichotomousAnalysisStruct(ctypes.Structure):
     ]
 
     def __str__(self) -> str:
+        n_prior = self.parms * self.prior_cols
         return dedent(
             f"""
             model: {self.model}
@@ -38,7 +39,7 @@ class DichotomousAnalysisStruct(ctypes.Structure):
             Y: {self.Y[:self.n]}
             doses: {self.doses[:self.n]}
             n_group: {self.n_group[:self.n]}
-            prior: {self.prior[:self.parms*self.prior_cols]}
+            prior<{n_prior}>: {self.prior[:n_prior]}
             BMD_type: {self.BMD_type}
             BMR: {self.BMR}
             alpha: {self.alpha}
@@ -444,6 +445,7 @@ class ContinuousAnalysisStruct(ctypes.Structure):
     def __str__(self) -> str:
         sd = self.sd[: self.n] if self.suff_stat else []
         n_group = self.n_group[: self.n] if self.suff_stat else []
+        n_prior = self.parms * self.prior_cols
         return dedent(
             f"""
             model: {self.model}
@@ -453,7 +455,7 @@ class ContinuousAnalysisStruct(ctypes.Structure):
             doses: {self.doses[:self.n]}
             sd: {sd}
             n_group: {n_group}
-            prior: {self.prior[:self.parms*self.prior_cols]}
+            prior<{n_prior}>: {self.prior[:n_prior]}
             BMD_type: {self.BMD_type}
             isIncreasing: {self.isIncreasing}
             BMR: {self.BMR}

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -121,7 +121,7 @@ def test_bmds3_decreasing(negative_contds):
         # (continuous.ExponentialM3, [-9999.0, -9999.0, -9999.0], -9999.0),  # TODO -fix
         # (continuous.ExponentialM5, [-9999.0, -9999.0, -9999.0], -9999.0),  # TODO -fix
         (continuous.Power, [56.5, 52.7, 58.9], 3077.5),
-        (continuous.Hill, [59.5, 53.1, 66.7], 3082.1),
+        (continuous.Hill, [55.5, 51.6, 68.7], 3082.1),
         # (continuous.Linear, [35.3, 33.1, 37.7], 3115.3),
         # (continuous.Polynomial, [52.7, 46.7, 57.7], -9999.0),  # TODO -fix AIC
     ]:
@@ -147,7 +147,7 @@ def test_bmds3_variance(contds):
     result = model.execute()
     assert model.settings.disttype is DistType.normal_ncv
     assert len(result.parameters.values) == 5
-    assert pytest.approx(result.bmd, abs=1.0) == -9999  # fix?
+    assert pytest.approx(result.bmd, abs=1.0) == 13.3
 
     # TODO -fix - currently segfault
     # model = continuous.Power(contds, dict(disttype=DistType.log_normal))

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 import bmds
-from bmds.bmds3.constants import DistType
+from bmds.bmds3.constants import ContinuousModelIds, DistType
 from bmds.bmds3.models import continuous
 from bmds.bmds3.types.continuous import ContinuousModelSettings
 
@@ -205,3 +205,20 @@ def test_bmds3_continuous_individual_session(cidataset):
     d = session.to_dict()
     # ensure json-serializable
     print(json.dumps(d))
+
+
+@pytest.mark.skip  # TODO - after update to dll this test should succeed
+def test_decreasing_lognormal(negative_contds):
+    """
+    When using the lognormal distribution type, only exponential models shoudl run;
+    all others should have the `has_completed` False
+    """
+    session = bmds.session.Bmds330(dataset=negative_contds)
+    session.add_default_models(global_settings=dict(disttype=DistType.log_normal))
+    session.execute()
+    for model in session.models:
+        should_complete = model.bmd_model_class.id in [
+            ContinuousModelIds.c_exp_m3,
+            ContinuousModelIds.c_exp_m5,
+        ]
+        assert model.results.has_completed is should_complete

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+# import numpy as np
 import pytest
 
 import bmds
@@ -98,41 +99,41 @@ def test_bmds3_increasing(contds):
     """
     # test increasing means dataset
     for Model, bmd_values, aic in [
-        # (continuous.ExponentialM3, [52.867, 50.457, 55.501], 3181.6),
-        # (continuous.ExponentialM5, [28.446, 27.025, 30.004], 3070.6),
-        (continuous.Power, [25.85, 24.462, 29.223], 3065.8),
-        (continuous.Hill, [29.639, 25.84, 33.288], 3072.8),
-        # (continuous.Linear, [70.738, 67.061, 74.722], 11896.4),
-        # (continuous.Polynomial, [65.872, 65.083, 69.618], -9999.0),  # TODO - fix AIC
+        (continuous.ExponentialM3, [157.492, 154.493, 169.93], 3842.8),
+        # (continuous.ExponentialM5, [nan, nan, nan], 3069.8),
+        (continuous.Power, [25.852, 24.4, 29.599], 3067.8),
+        (continuous.Hill, [29.25, 25.893, 33.209], 3071.3),
+        (continuous.Linear, [25.856, 24.388, 27.451], 3065.8),
+        (continuous.Polynomial, [25.55, 23.836, 27.57], 3068.0),
     ]:
         result = Model(contds).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
+        # res = f"(continuous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)}),"
         # print(res)
-        assert pytest.approx(bmd_values, abs=1.0) == actual, Model.__name__
-        assert pytest.approx(aic, abs=5.0) == result.fit.aic, Model.__name__
+        assert pytest.approx(bmd_values, rel=0.05) == actual, Model.__name__
+        assert pytest.approx(aic, rel=0.01) == result.fit.aic, Model.__name__
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
 def test_bmds3_decreasing(negative_contds):
     # test decreasing means dataset
     for Model, bmd_values, aic in [
-        # (continuous.ExponentialM3, [-9999.0, -9999.0, -9999.0], -9999.0),  # TODO -fix
-        # (continuous.ExponentialM5, [-9999.0, -9999.0, -9999.0], -9999.0),  # TODO -fix
-        (continuous.Power, [56.5, 52.7, 58.9], 3077.5),
-        (continuous.Hill, [55.5, 51.6, 68.7], 3082.1),
-        # (continuous.Linear, [35.3, 33.1, 37.7], 3115.3),
-        # (continuous.Polynomial, [52.7, 46.7, 57.7], -9999.0),  # TODO -fix AIC
+        # (continuous.ExponentialM3, [nan, nan, nan], 4296.0),
+        # (continuous.ExponentialM5, [nan, nan, nan], 4296.3),
+        (continuous.Power, [56.5, 54.3, 59.7], 3077.5),
+        # (continuous.Hill, [nan, nan, nan], 3925.8),
+        (continuous.Linear, [35.3, 33.1, 37.7], 3115.3),
+        (continuous.Polynomial, [51.5, 47.3, 56.5], 3074.7),
     ]:
-        result = Model(negative_contds).execute()
+        model = Model(negative_contds)
+        result = model.execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # import numpy as np
-        # res = f"(continuous.{Model.__name__}, {np.round(actual, 1).tolist()}, {round(result.fit.aic, 1)})"
+        # res = f"(continuous.{Model.__name__}, {np.round(actual, 1).tolist()}, {round(result.fit.aic, 1)}),"
         # print(res)
-        assert pytest.approx(bmd_values, abs=1.0) == actual, Model.__name__
-        assert pytest.approx(aic, abs=5.0) == result.fit.aic, Model.__name__
+        assert pytest.approx(bmd_values, rel=0.05) == actual, Model.__name__
+        assert pytest.approx(aic, rel=0.01) == result.fit.aic, Model.__name__
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)
@@ -161,23 +162,19 @@ def test_bmds3_variance(contds):
 def test_bmds3_continuous_polynomial(contds):
     # compare bmd, bmdl, bmdu, aic values
     for degree, bmd_values, aic in [
-        # (1, [25.746, 24.353, 27.508], 3065.9),  # TODO - totally different answer linux vs mac, why
-        # (2, [65.872, 65.083, 69.618], -9999.0),
-        # (3, [59.401, 57.257, 62.877], 11686.3),
+        (1, [25.856, 24.388, 27.451], 3065.8),
+        (2, [25.55, 23.836, 27.57], 3068.0),
+        (3, [25.681, 25.62, 26.083], 3070.1),
         # (4, [-9999.0, -9999.0, -9999.0], -9999.0),
-        # (5, [-9999.0, -9999.0, -9999.0], -9999.0),
-        # (6, [-9999.0, -9999.0, -9999.0], -9999.0),
-        # (7, [-9999.0, -9999.0, -9999.0], -9999.0),
-        # (8, [-9999.0, -9999.0, -9999.0], -9999.0),
     ]:
         settings = ContinuousModelSettings(degree=degree)
         result = continuous.Polynomial(contds, settings).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
-        # res = f"({degree}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
+        # res = f"({degree}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)}),"
         # print(res)
-        assert pytest.approx(actual, abs=1.0) == bmd_values, degree
-        assert pytest.approx(aic, abs=5.0) == result.fit.aic, degree
+        assert pytest.approx(actual, rel=0.05) == bmd_values, degree
+        assert pytest.approx(aic, rel=0.01) == result.fit.aic, degree
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)

--- a/tests/bmds3/test_bmds3_dich_models.py
+++ b/tests/bmds3/test_bmds3_dich_models.py
@@ -55,7 +55,7 @@ def test_bmds3_dichotomous_models(dichds):
         (dichotomous.Gamma, [66.061, 57.639, 73.716], 361.6),
         (dichotomous.QuantalLinear, [17.679, 15.645, 20.062], 425.6),
         (dichotomous.Weibull, [64.26, 55.219, 72.815], 358.4),
-        (dichotomous.DichotomousHill, [68.178, 59.795, 75.999], 363.0),
+        (dichotomous.DichotomousHill, [68.178, 59.795, 75.999], 364.0),
     ]:
         model = Model(dichds)
         result = model.execute()
@@ -75,11 +75,7 @@ def test_bmds3_dichotomous_multistage(dichds):
         (1, [17.680, 15.645, 20.062], 425.6),
         (2, [48.016, 44.136, 51.240], 369.7),
         (3, [63.873, 52.260, 72.126], 358.5),
-        # (4, [69.583, 61.194, 77.945], 363.957),  # TODO -fix
-        # (5, [63.476, 51.826, 78.311], 356.416),  # TODO -fix
-        # (6, [63.665, 11.083, 82.846], 366.384),  # TODO -fix
-        # (7, [69.583, 61.194, 77.945], 363.957),  # TODO -fix
-        # (8, [64.501, 51.366, 85.041], 366.382),  # TODO -fix
+        (4, [63.871, 52.073, 72.725], 358.5),
     ]:
         settings = DichotomousModelSettings(degree=degree)
         model = dichotomous.Multistage(dichds, settings)
@@ -87,8 +83,8 @@ def test_bmds3_dichotomous_multistage(dichds):
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for modifying values
         # print(f"({degree}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})")
-        assert pytest.approx(bmd_values, abs=0.1) == actual
-        assert pytest.approx(aic, abs=3.0) == result.fit.aic
+        assert pytest.approx(bmd_values, abs=0.5) == actual
+        assert pytest.approx(aic, abs=5.0) == result.fit.aic
 
 
 @pytest.mark.skipif(not should_run, reason=skip_reason)

--- a/tests/bmds3/test_bmds3_dich_models.py
+++ b/tests/bmds3/test_bmds3_dich_models.py
@@ -48,14 +48,14 @@ class TestBmdModelDichotomous:
 def test_bmds3_dichotomous_models(dichds):
     # compare bmd, bmdl, bmdu, aic values
     for Model, bmd_values, aic in [
-        (dichotomous.Logistic, [69.583, 61.194, 77.945], 364.0),
-        (dichotomous.LogLogistic, [68.163, 59.795, 75.998], 365.0),
-        (dichotomous.Probit, [66.874, 58.335, 75.368], 362.1),
-        (dichotomous.LogProbit, [66.138, 58.681, 73.153], 366.3),
-        (dichotomous.Gamma, [66.037, 57.639, 73.715], 363.6),
+        (dichotomous.Logistic, [69.584, 61.193, 77.945], 364.0),
+        (dichotomous.LogLogistic, [68.361, 59.795, 76.012], 365.0),
+        (dichotomous.Probit, [66.883, 58.333, 75.368], 362.1),
+        (dichotomous.LogProbit, [66.149, 58.684, 73.16], 366.3),
+        (dichotomous.Gamma, [66.061, 57.639, 73.716], 361.6),
         (dichotomous.QuantalLinear, [17.679, 15.645, 20.062], 425.6),
-        (dichotomous.Weibull, [64.242, 55.219, 72.814], 358.0),
-        (dichotomous.DichotomousHill, [68.173, 59.795, 75.998], 365.0),
+        (dichotomous.Weibull, [64.26, 55.219, 72.815], 358.4),
+        (dichotomous.DichotomousHill, [68.178, 59.795, 75.999], 363.0),
     ]:
         model = Model(dichds)
         result = model.execute()
@@ -64,7 +64,7 @@ def test_bmds3_dichotomous_models(dichds):
         # print(
         #     f"(dichotomous.{Model.__name__}, {np.round(actual, 3).tolist()}, {round(result.fit.aic, 1)})"
         # )
-        assert pytest.approx(bmd_values, abs=0.1) == actual
+        assert pytest.approx(bmd_values, abs=0.5) == actual
         assert pytest.approx(aic, abs=3.0) == result.fit.aic
 
 

--- a/tests/bmds3/test_bmds3_priors.py
+++ b/tests/bmds3/test_bmds3_priors.py
@@ -6,51 +6,17 @@ from bmds.bmds3 import constants
 
 @pytest.fixture
 def mock_prior():
+    t = constants.PriorType.eNone
     return constants.ModelPriors(
         prior_class=constants.PriorClass.frequentist_restricted,
         priors=[
-            constants.Prior(
-                name="a",
-                type=constants.PriorType.eNone,
-                initial_value=1,
-                stdev=1,
-                min_value=1,
-                max_value=1,
-            ),
-            constants.Prior(
-                name="b",
-                type=constants.PriorType.eNone,
-                initial_value=2,
-                stdev=2,
-                min_value=2,
-                max_value=2,
-            ),
-            constants.Prior(
-                name="c",
-                type=constants.PriorType.eNone,
-                initial_value=3,
-                stdev=3,
-                min_value=3,
-                max_value=3,
-            ),
+            constants.Prior(name="a", type=t, initial_value=1, stdev=1, min_value=1, max_value=1),
+            constants.Prior(name="b", type=t, initial_value=2, stdev=2, min_value=2, max_value=2),
+            constants.Prior(name="c", type=t, initial_value=3, stdev=3, min_value=3, max_value=3),
         ],
         variance_priors=[
-            constants.Prior(
-                name="d",
-                type=constants.PriorType.eNone,
-                initial_value=4,
-                stdev=4,
-                min_value=4,
-                max_value=4,
-            ),
-            constants.Prior(
-                name="e",
-                type=constants.PriorType.eNone,
-                initial_value=5,
-                stdev=5,
-                min_value=5,
-                max_value=5,
-            ),
+            constants.Prior(name="d", type=t, initial_value=4, stdev=4, min_value=4, max_value=4),
+            constants.Prior(name="e", type=t, initial_value=5, stdev=5, min_value=5, max_value=5),
         ],
     )
 

--- a/tests/bmds3/test_bmds3_recommender.py
+++ b/tests/bmds3/test_bmds3_recommender.py
@@ -56,9 +56,9 @@ class TestSessionRecommender:
         assert session.recommender.results.model_bin == [0, 0]
 
         # model recommended and selection is accurate
-        assert session.recommender.results.recommended_model_index == 0
+        assert session.recommender.results.recommended_model_index == 1
         assert session.recommender.results.recommended_model_variable == "aic"
-        assert session.models[0].results.fit.aic < session.models[1].results.fit.aic
+        assert session.models[1].results.fit.aic < session.models[0].results.fit.aic
 
     def test_apply_logic_cont(self, cdataset):
         session = bmds.session.Bmds330(dataset=cdataset)


### PR DESCRIPTION
Updated code to use latest model averaging components from dll.

Additional changes:

- added new diagnostic tests to print priors object as a string
- check dll successful flag to determine if model has results
- update model prior for c for exp3 even if unused; required for model execution
