### PR TITLE
matplotlib model averaging plot

### DIFF
--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -144,46 +144,13 @@ class BmdModel(abc.ABC):
             label=self.name(),
             **plotting.LINE_FORMAT,
         )
-        self._add_bmr_lines(ax)
+        plotting.add_bmr_lines(ax, self.results.bmd, self.results.bmdl, self.results.plotting.bmd_y)
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
 
     @abc.abstractmethod
     def get_param_names(self) -> List[str]:
         ...
-
-    def _add_bmr_lines(self, ax):
-        res = self.results
-        xdomain = ax.xaxis.get_view_interval()
-        xrng = xdomain[1] - xdomain[0]
-
-        if res.bmd > 0:
-            ax.plot(
-                [0, res.bmd], [res.plotting.bmd_y, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT
-            )
-            ax.plot(
-                [res.bmd, res.bmd], [0, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT,
-            )
-            ax.text(
-                res.bmd + xrng * 0.01,
-                0,
-                "BMD",
-                label="BMR, BMD, BMDL",
-                horizontalalignment="left",
-                verticalalignment="center",
-                **plotting.BMD_LABEL_FORMAT,
-            )
-
-        if res.bmdl > 0:
-            ax.plot([res.bmdl, res.bmdl], [0, res.plotting.bmd_y], **plotting.BMD_LINE_FORMAT)
-            ax.text(
-                res.bmdl - xrng * 0.01,
-                0,
-                "BMDL",
-                horizontalalignment="right",
-                verticalalignment="center",
-                **plotting.BMD_LABEL_FORMAT,
-            )
 
     def to_dict(self) -> Dict:
         return self.serialize().dict()
@@ -242,6 +209,10 @@ class BmdModelAveraging(abc.ABC):
 
     @abc.abstractmethod
     def serialize(self, session) -> "BmdModelAveragingSchema":
+        ...
+
+    @abc.abstractmethod
+    def plot(self):
         ...
 
     def to_dict(self) -> Dict:

--- a/bmds/bmds3/models/ma.py
+++ b/bmds/bmds3/models/ma.py
@@ -1,6 +1,8 @@
 import ctypes
+from itertools import cycle
 from typing import List
 
+from ... import plotting
 from ..types.dichotomous import DichotomousModelSettings
 from ..types.ma import DichotomousModelAverageResult
 from ..types.structs import DichotomousMAStructs
@@ -39,6 +41,37 @@ class BmdModelAveragingDichotomous(BmdModelAveraging):
         return BmdModelAveragingDichotomousSchema(
             settings=self.settings, model_indexes=model_indexes, results=self.results
         )
+
+    def plot(self):
+        """
+        After model execution, print the dataset, curve-fit, BMD, and BMDL.
+        """
+        if not self.has_results:
+            raise ValueError("Cannot plot if results are unavailable")
+        dataset = self.session.dataset
+        results = self.results
+        fig = dataset.plot()
+        ax = fig.gca()
+        ax.set_ylim(-0.05, 1.05)
+        title = f"{dataset._get_dataset_name()}\nModel average, {self.settings.bmr_text()}"
+        ax.set_title(title)
+        color_cycle = cycle(plotting.INDIVIDUAL_MODEL_COLORS)
+        line_cycle = cycle(plotting.INDIVIDUAL_LINE_STYLES)
+        for model in self.session.models:
+            ax.plot(
+                model.results.plotting.dr_x,
+                model.results.plotting.dr_y,
+                label=model.name(),
+                c=next(color_cycle),
+                linestyle=next(line_cycle),
+                lw=2,
+            )
+        ax.plot(
+            self.results.dr_x, self.results.dr_y, label="Model average", c="#6470C0", lw=4,
+        )
+        plotting.add_bmr_lines(ax, results.bmd, results.bmdl, results.bmd_y)
+        ax.legend(**plotting.LEGEND_OPTS)
+        return fig
 
 
 class BmdModelAveragingDichotomousSchema(BmdModelAveragingSchema):

--- a/bmds/bmds3/recommender/checks.py
+++ b/bmds/bmds3/recommender/checks.py
@@ -331,11 +331,11 @@ class NoDegreesOfFreedom(Check):
         if dataset.dtype in constants.DICHOTOMOUS_DTYPES:
             value = model.results.gof.df
         elif dataset.dtype in constants.CONTINUOUS_DTYPES:
-            value = 1  # TODO - fix
+            value = model.results.fit.total_df
         else:
             raise ValueError("Unknown dtype")
 
-        if value > 0:
+        if value > constants.ZEROISH:
             return CheckResponse.success()
         else:
             return CheckResponse(
@@ -347,7 +347,6 @@ class NoDegreesOfFreedom(Check):
 class Warnings(Check):
     @classmethod
     def apply_rule(cls, settings, dataset, output) -> CheckResponse:
-        # TODO - doesn't exist with bmds3?
         return CheckResponse.success()
 
 

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -140,7 +140,7 @@ class Recommender:
             return
 
         if hasattr(dataset, "_anova"):
-            # force recalculation - TODO - fix? this shouldn't be necessary - is serialization is causing?
+            # force recalculation - TODO - fix? shouldn't be necessary - is serialization causing?
             del dataset._anova
             dataset.anova()
 

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
 
 
 def write_dataset(report: Report, dataset: DatasetBase):
-    # TODO - doses dropped
-    # TODO - dataset name (@ session level); session name if exists, else datset name, else dataset id, else "BMDS Session"
     styles = report.styles
     footnotes = TableFootnote()
 

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -152,7 +152,9 @@ def write_frequentist_table(report: Report, session: BmdsSession):
 
 
 def plot_bma(report: Report, session: BmdsSession):
-    pass  # TODO - implement!
+    if session.model_average.has_results:
+        fig = session.model_average.plot()
+        report.document.add_paragraph(add_mpl_figure(report.document, fig, 6))
 
 
 def write_bayesian_table(report: Report, session: BmdsSession):

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -251,9 +251,9 @@ class BmdsSession:
 
         if self.is_bayesian():
             report.document.add_paragraph("Bayesian Summary", h2)
+            reporting.write_bayesian_table(report, self)
             if self.model_average:
                 reporting.plot_bma(report, self)
-            reporting.write_bayesian_table(report, self)
         else:
             report.document.add_paragraph("Frequentist Summary", h2)
             reporting.write_frequentist_table(report, self)

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -149,7 +149,7 @@ class BmdsSession:
 
         Looks at the first model's prior to determine if it's bayesian, else assume frequentist.
         """
-        # TODO - fix; will not handle PriorClass.custom
+        # TODO - fix with handle PriorClass.custom
         first_class = self.models[0].settings.priors.prior_class
         return first_class is PriorClass.bayesian
 

--- a/bmds/datasets/dichotomous.py
+++ b/bmds/datasets/dichotomous.py
@@ -122,7 +122,11 @@ class DichotomousDataset(DatasetBase):
             means, lls, uls = zip(
                 *[self._calculate_plotting(i, j) for i, j in zip(self.ns, self.incidences)]
             )
-            self._plot_data = DatasetPlottingSchema(mean=means, ll=lls, ul=uls)
+            self._plot_data = DatasetPlottingSchema(
+                mean=means,
+                ll=(np.array(means) - np.array(lls)).clip(0).tolist(),
+                ul=(np.array(uls) - np.array(means)).clip(0).tolist(),
+            )
         return self._plot_data
 
     def plot(self):

--- a/bmds/plotting.py
+++ b/bmds/plotting.py
@@ -10,7 +10,7 @@ __all__ = []
 PLOT_FIGSIZE = (8, 5)
 DPI = 100
 PLOT_MARGINS = 0.05
-DATASET_POINT_FORMAT = dict(ms=7, fmt="o", c="k")
+DATASET_POINT_FORMAT = dict(ms=7, fmt="o", c="k", capsize=3, lw=1)
 DATASET_INDIVIDUAL_FORMAT = dict(s=35, alpha=0.60, c="k")
 LEGEND_OPTS = dict(loc="best", fontsize=8, fancybox=True, frameon=True)
 LINE_FORMAT = dict(c="#6470C0", lw=3)

--- a/bmds/plotting.py
+++ b/bmds/plotting.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import matplotlib as mpl
 import matplotlib.pyplot as plt  # noqa
 
@@ -12,6 +14,8 @@ DATASET_POINT_FORMAT = dict(ms=7, fmt="o", c="k")
 DATASET_INDIVIDUAL_FORMAT = dict(s=35, alpha=0.60, c="k")
 LEGEND_OPTS = dict(loc="best", fontsize=8, fancybox=True, frameon=True)
 LINE_FORMAT = dict(c="#6470C0", lw=3)
+INDIVIDUAL_MODEL_COLORS = ["#6e40aa", "#e7298a", "#1b9e77", "#cc7939", "#666666"]
+INDIVIDUAL_LINE_STYLES = ["solid", "dotted", "dashed", "dashdot"]
 BMD_LINE_FORMAT = dict(c="#BFC05D", lw=2)
 BMD_LABEL_FORMAT = dict(size=9)
 FAILURE_MESSAGE_FORMAT = dict(
@@ -32,3 +36,34 @@ def create_empty_figure():
 
 def close_figure(fig):
     plt.close(fig)
+
+
+def add_bmr_lines(
+    ax, bmd: Optional[float] = None, bmdl: Optional[float] = None, bmd_y: Optional[float] = None
+):
+    xdomain = ax.xaxis.get_view_interval()
+    xrng = xdomain[1] - xdomain[0]
+
+    if bmd and bmd > 0:
+        ax.plot([0, bmd], [bmd_y, bmd_y], **BMD_LINE_FORMAT)
+        ax.plot([bmd, bmd], [0, bmd_y], **BMD_LINE_FORMAT)
+        ax.text(
+            bmd + xrng * 0.01,
+            0,
+            "BMD",
+            label="BMR, BMD, BMDL",
+            horizontalalignment="left",
+            verticalalignment="center",
+            **BMD_LABEL_FORMAT,
+        )
+
+    if bmdl and bmdl > 0:
+        ax.plot([bmdl, bmdl], [0, bmd_y], **BMD_LINE_FORMAT)
+        ax.text(
+            bmdl - xrng * 0.01,
+            0,
+            "BMDL",
+            horizontalalignment="right",
+            verticalalignment="center",
+            **BMD_LABEL_FORMAT,
+        )

--- a/tests/bmds3/run3.py
+++ b/tests/bmds3/run3.py
@@ -1,0 +1,7 @@
+import os
+
+
+# TODO remove when dll released
+class RunBmds3:
+    should_run = os.getenv("CI") is None
+    skip_reason = "DLLs not present on CI"

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -189,6 +189,7 @@ def test_bmds3_continuous_session(cdataset2):
     print(json.dumps(d))
 
 
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 def test_decreasing_lognormal(negative_cdataset):
     session = bmds.session.Bmds330(dataset=negative_cdataset)
     settings = dict(disttype=DistType.log_normal, degree=2)

--- a/tests/bmds3/test_bmds3_cont_models.py
+++ b/tests/bmds3/test_bmds3_cont_models.py
@@ -23,13 +23,30 @@ class TestPriorOverrides:
         assert model.settings.priors.priors[2].min_value == -18
         assert model.settings.priors.priors[2].max_value == 0
 
-    def test_hill(self, cdataset2, negative_cdataset):
-        # TODO - add ...
-        ...
+    def test_hill(self, cdataset2):
+        cv = continuous.Hill(cdataset2, settings=dict(disttype=DistType.normal)).settings.priors
+        assert cv.get_prior("v").min_value == -1e8
+
+        ln = continuous.Hill(cdataset2, settings=dict(disttype=DistType.log_normal)).settings.priors
+        assert ln.get_prior("v").min_value == -1e8
+
+        ncv = continuous.Hill(
+            cdataset2, settings=dict(disttype=DistType.normal_ncv)
+        ).settings.priors
+        assert ncv.get_prior("v").min_value == -1000
 
     def test_poly(self, cdataset2, negative_cdataset):
-        # TODO - add ...
-        ...
+        model = continuous.Polynomial(cdataset2)
+        model.settings.priors.priors[1].min_value == 0
+        model.settings.priors.priors[1].max_value == 1e8
+        model.settings.priors.priors[2].min_value == 0
+        model.settings.priors.priors[2].max_value == 1e8
+
+        model = continuous.Polynomial(negative_cdataset)
+        model.settings.priors.priors[1].min_value = -1e8
+        model.settings.priors.priors[1].max_value == 0
+        model.settings.priors.priors[2].min_value == -1e8
+        model.settings.priors.priors[2].max_value == 0
 
 
 class TestBmdModelContinuous:

--- a/tests/bmds3/test_bmds3_indiv_cont_models.py
+++ b/tests/bmds3/test_bmds3_indiv_cont_models.py
@@ -1,16 +1,11 @@
-import os
-
 # import numpy as np
 import pytest
+from run3 import RunBmds3
 
 from bmds.bmds3.models import continuous
 
-# TODO remove this restriction
-should_run = os.getenv("CI") is None
-skip_reason = "DLLs not present on CI"
 
-
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 def test_bmds3_increasing(cidataset):
     for Model, bmd_values, aic in [
         (continuous.ExponentialM3, [394.278, 257.847, 877.507], 116.4),

--- a/tests/bmds3/test_bmds3_ma_models.py
+++ b/tests/bmds3/test_bmds3_ma_models.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import numpy as np
 import pytest

--- a/tests/bmds3/test_bmds3_ma_models.py
+++ b/tests/bmds3/test_bmds3_ma_models.py
@@ -3,35 +3,25 @@ import os
 
 import numpy as np
 import pytest
+from run3 import RunBmds3
 
 import bmds
 from bmds.bmds3.constants import PriorClass
 
-# TODO remove this restriction
-should_run = os.getenv("CI") is None
-skip_reason = "DLLs not present on CI"
 
-
-@pytest.fixture
-def dichds():
-    return bmds.DichotomousDataset(
-        doses=[0, 50, 100, 150, 200], ns=[100, 100, 100, 100, 100], incidences=[0, 5, 30, 65, 90]
-    )
-
-
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestDichotomousMa:
-    def test_bmds3_dichotomous_ma_session(self, dichds):
+    def test_bmds3_dichotomous_ma_session(self, ddataset2):
         # check execution and it can be json serialized
-        session = bmds.session.Bmds330(dataset=dichds)
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_default_bayesian_models()
         session.execute()
         d = session.to_dict()
         assert isinstance(json.dumps(d), str)
 
-    def test_prior_weights(self, dichds):
+    def test_prior_weights(self, ddataset2):
         # default; equal weights
-        session = bmds.session.Bmds330(dataset=dichds)
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_model(bmds.constants.M_Logistic, {"priors": PriorClass.bayesian})
         session.add_model(bmds.constants.M_Probit, {"priors": PriorClass.bayesian})
         session.add_model_averaging()
@@ -41,7 +31,7 @@ class TestDichotomousMa:
         assert np.allclose(session.model_average.results.posteriors, [0.065, 0.94], atol=0.05)
 
         # custom; propagate through results
-        session = bmds.session.Bmds330(dataset=dichds)
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_model(bmds.constants.M_Logistic, {"priors": PriorClass.bayesian})
         session.add_model(bmds.constants.M_Probit, {"priors": PriorClass.bayesian})
         session.add_model_averaging(weights=[0.9, 0.1])

--- a/tests/bmds3/test_bmds3_recommender.py
+++ b/tests/bmds3/test_bmds3_recommender.py
@@ -1,25 +1,14 @@
-import os
 from unittest import mock
 
 import pytest
 from pydantic import ValidationError
+from run3 import RunBmds3
 
 import bmds
 from bmds.bmds3.constants import BMDS_BLANK_VALUE
 from bmds.bmds3.recommender.checks import AicExists, GoodnessOfFit, LargeRoi, NoDegreesOfFreedom
 from bmds.bmds3.recommender.recommender import Recommender, RecommenderSettings, Rule, RuleClass
 from bmds.constants import Dtype, LogicBin
-
-# TODO remove this restriction
-should_run = os.getenv("CI") is None
-skip_reason = "DLLs not present on CI"
-
-
-@pytest.fixture
-def dichds():
-    return bmds.DichotomousDataset(
-        doses=[0, 50, 100, 150, 200], ns=[100, 100, 100, 100, 100], incidences=[0, 5, 30, 65, 90]
-    )
 
 
 class TestRecommenderSettings:
@@ -44,10 +33,10 @@ class TestRecommender:
         assert df.shape == (22, 6)
 
 
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestSessionRecommender:
-    def test_apply_logic_dich(self, dichds):
-        session = bmds.session.Bmds330(dataset=dichds)
+    def test_apply_logic_dich(self, ddataset2):
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_model(bmds.constants.M_DichotomousHill)
         session.add_model(bmds.constants.M_Gamma)
         session.execute_and_recommend()

--- a/tests/bmds3/test_bmds3_selection.py
+++ b/tests/bmds3/test_bmds3_selection.py
@@ -1,25 +1,13 @@
-import os
-
 import pytest
+from run3 import RunBmds3
 
 import bmds
 
-# TODO remove this restriction
-should_run = os.getenv("CI") is None
-skip_reason = "DLLs not present on CI"
 
-
-@pytest.fixture
-def dichds():
-    return bmds.DichotomousDataset(
-        doses=[0, 50, 100, 150, 200], ns=[100, 100, 100, 100, 100], incidences=[0, 5, 30, 65, 90]
-    )
-
-
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestBmdsSelector:
-    def test_selection(self, dichds):
-        session = bmds.session.Bmds330(dataset=dichds)
+    def test_selection(self, ddataset2):
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_model(bmds.constants.M_Logistic)
         session.execute_and_recommend()
 

--- a/tests/bmds3/test_bmds3_sessions.py
+++ b/tests/bmds3/test_bmds3_sessions.py
@@ -125,6 +125,11 @@ class TestBmdsSessionBatch:
             session.execute_and_recommend()
             batch.sessions.append(session)
 
+            session = bmds.session.Bmds330(dataset=dataset)
+            session.add_default_bayesian_models()
+            session.execute()
+            batch.sessions.append(session)
+
         # check serialization/deserialization
         data = batch.serialize()
         batch2 = batch.deserialize(data)

--- a/tests/bmds3/test_bmds3_sessions.py
+++ b/tests/bmds3/test_bmds3_sessions.py
@@ -1,40 +1,19 @@
 import json
-import os
 from pathlib import Path
 
 import pytest
+from run3 import RunBmds3
 
 import bmds
 from bmds import constants
 from bmds.bmds3 import BmdsSession, BmdsSessionBatch
 
-# TODO remove this restriction
-should_run = os.getenv("CI") is None
-skip_reason = "DLLs not present on CI"
 
-
-@pytest.fixture
-def dichds():
-    return bmds.DichotomousDataset(
-        doses=[0, 50, 100, 150, 200], ns=[100, 100, 100, 100, 100], incidences=[0, 5, 30, 65, 90]
-    )
-
-
-@pytest.fixture
-def contds():
-    return bmds.ContinuousDataset(
-        doses=[0, 50, 100, 150, 200],
-        ns=[100, 100, 100, 100, 100],
-        means=[10, 20, 30, 40, 50],
-        stdevs=[3, 4, 5, 6, 7],
-    )
-
-
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestBmds330:
-    def test_serialization(self, dichds):
+    def test_serialization(self, ddataset2):
         # make sure serialize looks correct
-        session1 = bmds.session.Bmds330(dataset=dichds)
+        session1 = bmds.session.Bmds330(dataset=ddataset2)
         session1.add_default_models()
         session1.execute_and_recommend()
         d = session1.to_dict()
@@ -66,9 +45,9 @@ class TestBmds330:
         d2 = session2.serialize().dict()
         assert d1 == d2
 
-    def test_serialization_ma(self, dichds, data_path, rewrite_data_files):
+    def test_serialization_ma(self, ddataset2, data_path, rewrite_data_files):
         # make sure serialize looks correct
-        session1 = bmds.session.Bmds330(dataset=dichds)
+        session1 = bmds.session.Bmds330(dataset=ddataset2)
         session1.add_default_models()
         session1.add_model_averaging()
         session1.execute_and_recommend()
@@ -97,9 +76,9 @@ class TestBmds330:
         d2 = session2.serialize().dict()
         assert d1 == d2
 
-    def test_exports(self, dichds, rewrite_data_files):
+    def test_exports(self, ddataset2, rewrite_data_files):
         # make sure serialize looks correct
-        session = bmds.session.Bmds330(dataset=dichds)
+        session = bmds.session.Bmds330(dataset=ddataset2)
         session.add_default_models()
         session.execute_and_recommend()
 
@@ -114,10 +93,10 @@ class TestBmds330:
             docx.save(Path("~/Desktop/bmds3-dichotomous.docx").expanduser())
 
 
-@pytest.mark.skipif(not should_run, reason=skip_reason)
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestBmdsSessionBatch:
-    def test_exports_dichotomous(self, dichds, rewrite_data_files):
-        datasets = [dichds]
+    def test_exports_dichotomous(self, ddataset2, rewrite_data_files):
+        datasets = [ddataset2]
         batch = BmdsSessionBatch()
         for dataset in datasets:
             session = bmds.session.Bmds330(dataset=dataset)
@@ -143,8 +122,8 @@ class TestBmdsSessionBatch:
             df.to_excel(Path("~/Desktop/bmds3-d-batch.xlsx").expanduser(), index=False)
             docx.save(Path("~/Desktop/bmds3-d-batch.docx").expanduser())
 
-    def test_exports_continuous(self, contds, cidataset, rewrite_data_files):
-        datasets = [contds, cidataset]
+    def test_exports_continuous(self, cdataset2, cidataset, rewrite_data_files):
+        datasets = [cdataset2, cidataset]
         batch = BmdsSessionBatch()
         for dataset in datasets:
             session = bmds.session.Bmds330(dataset=dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,26 @@ def cdataset():
 
 
 @pytest.fixture
+def cdataset2():
+    return bmds.ContinuousDataset(
+        doses=[0, 50, 100, 150, 200],
+        ns=[100, 100, 100, 100, 100],
+        means=[10, 20, 30, 40, 50],
+        stdevs=[3, 4, 5, 6, 7],
+    )
+
+
+@pytest.fixture
+def negative_cdataset():
+    return bmds.ContinuousDataset(
+        doses=[0, 50, 100, 150, 200],
+        ns=[100, 100, 100, 100, 100],
+        means=[1, -5, -10, -20, -30],
+        stdevs=[3, 4, 5, 6, 7],
+    )
+
+
+@pytest.fixture
 def cidataset():
     # fmt: off
     return bmds.ContinuousIndividualDataset(
@@ -77,6 +97,13 @@ def cidataset():
 def ddataset():
     return bmds.DichotomousDataset(
         doses=[0, 1.96, 5.69, 29.75], ns=[75, 49, 50, 49], incidences=[5, 1, 3, 14]
+    )
+
+
+@pytest.fixture
+def ddataset2():
+    return bmds.DichotomousDataset(
+        doses=[0, 50, 100, 150, 200], ns=[100, 100, 100, 100, 100], incidences=[0, 5, 30, 65, 90]
     )
 
 


### PR DESCRIPTION
Plotting changes:

- Build bayesian model average (BMA) plot in matplotlib for use in static reports (png, svg, etc)
- add BMA plot to word report 
- plots - reduce error-bar width
- plots - make `dataset.plot_data` internally consistent between continuous and dichotomous

Testing updates:

- cleanup fixtures, and TODOs
- add additional tests which were previously TODOs

**Example plot:**
![image](https://user-images.githubusercontent.com/999952/131548387-1266dbb1-425b-428f-b749-9d47707b9878.png)
