### PR TITLE
updated word report for input dataset

### DIFF
--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -157,13 +157,12 @@ class BmdModel(abc.ABC):
             raise ValueError("Cannot plot if results are unavailable")
         fig = plotting.create_empty_figure()
         ax = fig.gca()
-        ax.set_xlabel(self.results.plotting.dr_x)
+        ax.set_xlabel(self.dataset.get_xlabel())
         ax.set_ylabel("Percentile")
-        ax.scatter(
+        ax.plot(
             self.results.fit.bmd_dist[0], self.results.fit.bmd_dist[1], **plotting.LINE_FORMAT,
         )
-        ax.set_title("BMD cumulative\ndistribution function")
-        ax.legend(**plotting.LEGEND_OPTS)
+        ax.set_title("BMD cumulative distribution function")
         return fig
 
     @abc.abstractmethod

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -149,9 +149,6 @@ class BmdModel(abc.ABC):
         return fig
 
     def cdfPlot(self):
-        """
-        After model execution, print the cdf plot. 
-        """
         if not self.has_results:
             raise ValueError("Cannot plot if results are unavailable")
         fig = plotting.create_empty_figure()

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -148,6 +148,26 @@ class BmdModel(abc.ABC):
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
 
+    def cdfPlot(self):
+        """
+        After model execution, print the cdf plot. 
+        """
+        if not self.has_results:
+            raise ValueError("Cannot plot if results are unavailable")
+        fig = plotting.create_empty_figure()
+        ax = fig.gca()
+        ax.set_xlabel(plotting.CDF_X_LABEL)
+        ax.set_ylabel(plotting.CDF_Y_LABEL)
+        ax.scatter(
+            self.results.fit.bmd_dist[0],
+            self.results.fit.bmd_dist[1],
+            label="BMD",
+            **plotting.LINE_FORMAT,
+        )
+        ax.set_title(plotting.CDF_TITLE)
+        ax.legend(**plotting.LEGEND_OPTS)
+        return fig
+
     @abc.abstractmethod
     def get_param_names(self) -> List[str]:
         ...

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -148,20 +148,17 @@ class BmdModel(abc.ABC):
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
 
-    def cdfPlot(self):
+    def cdf_plot(self):
         if not self.has_results:
             raise ValueError("Cannot plot if results are unavailable")
         fig = plotting.create_empty_figure()
         ax = fig.gca()
-        ax.set_xlabel(plotting.CDF_X_LABEL)
-        ax.set_ylabel(plotting.CDF_Y_LABEL)
+        ax.set_xlabel(self.results.plotting.dr_x)
+        ax.set_ylabel("Percentile")
         ax.scatter(
-            self.results.fit.bmd_dist[0],
-            self.results.fit.bmd_dist[1],
-            label="BMD",
-            **plotting.LINE_FORMAT,
+            self.results.fit.bmd_dist[0], self.results.fit.bmd_dist[1], **plotting.LINE_FORMAT,
         )
-        ax.set_title(plotting.CDF_TITLE)
+        ax.set_title("BMD cumulative\ndistribution function")
         ax.legend(**plotting.LEGEND_OPTS)
         return fig
 

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -14,8 +14,14 @@ if TYPE_CHECKING:
     from .sessions import BmdsSession
 
 
-def write_dataset(report: Report, dataset: DatasetBase):
-    long = True
+def write_dataset_tbl(report: Report, dataset: DatasetBase, long: bool = True):
+    """Write dataset table to word report
+
+    Args:
+        report (Report): A report instance
+        dataset (DatasetBase): A dataset
+        long (bool, optional): Write in long (default) or condensed form.
+    """
     styles = report.styles
     footnotes = TableFootnote()
 
@@ -40,6 +46,11 @@ def write_dataset(report: Report, dataset: DatasetBase):
                 write_cell(tbl.cell(i + 1, 1), n, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 2), mean, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 3), stdev, styles.tbl_body)
+
+            width = styles.portrait_width / 4
+            for i, col in enumerate(tbl.columns):
+                set_column_width(col, width)
+
         else:
 
             tbl = report.document.add_table(3, dataset.num_dose_groups + 1, style=styles.table)
@@ -70,6 +81,11 @@ def write_dataset(report: Report, dataset: DatasetBase):
                 write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 1), n, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 2), inc, styles.tbl_body)
+
+            width = styles.portrait_width / 3
+            for i, col in enumerate(tbl.columns):
+                set_column_width(col, width)
+
         else:
 
             tbl = report.document.add_table(2, dataset.num_dose_groups + 1, style=styles.table)
@@ -109,6 +125,11 @@ def write_dataset(report: Report, dataset: DatasetBase):
             for i, (dose, response) in enumerate(zip(dataset.individual_doses, dataset.responses)):
                 write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 1), response, styles.tbl_body)
+
+            width = styles.portrait_width / 2
+            for i, col in enumerate(tbl.columns):
+                set_column_width(col, width)
+
         else:
 
             # create a table
@@ -122,6 +143,9 @@ def write_dataset(report: Report, dataset: DatasetBase):
             for i, row in df.iterrows():
                 write_cell(tbl.cell(i + 1, 0), row.dose, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 1), row.response, styles.tbl_body)
+
+            set_column_width(tbl.columns, 1)
+            set_column_width(tbl.columns, styles.portrait_width - 1)
 
     else:
         raise ValueError("Unknown dtype: {dataset.dtype}")
@@ -261,5 +285,5 @@ def write_models(report: Report, session: BmdsSession, header_level: int):
         report.document.add_paragraph(model.name(), header_style)
         if model.has_results:
             report.document.add_paragraph(add_mpl_figure(report.document, model.plot(), 6))
-            report.document.add_paragraph(add_mpl_figure(report.document, model.cdfPlot(), 6))
+            report.document.add_paragraph(add_mpl_figure(report.document, model.cdf_plot(), 6))
         report.document.add_paragraph(model.text(), styles.fixed_width)

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -139,8 +139,7 @@ def write_dataset_tbl(report: Report, dataset: DatasetBase, long: bool = True):
                 write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 1), response, styles.tbl_body)
 
-            width = styles.portrait_width / 2
-            for i, col in enumerate(tbl.columns):
+            for col, width in zip(tbl.columns, [1, styles.portrait_width - 1]):
                 set_column_width(col, width)
 
         else:
@@ -157,8 +156,8 @@ def write_dataset_tbl(report: Report, dataset: DatasetBase, long: bool = True):
                 write_cell(tbl.cell(i + 1, 0), row.dose, styles.tbl_body)
                 write_cell(tbl.cell(i + 1, 1), row.response, styles.tbl_body)
 
-            set_column_width(tbl.columns, 1)
-            set_column_width(tbl.columns, styles.portrait_width - 1)
+            for col, width in zip(tbl.columns, [1, styles.portrait_width - 1]):
+                set_column_width(col, width)
 
     else:
         raise ValueError("Unknown dtype: {dataset.dtype}")

--- a/bmds/bmds3/reporting.py
+++ b/bmds/bmds3/reporting.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 def write_dataset(report: Report, dataset: DatasetBase):
+    long = True
     styles = report.styles
     footnotes = TableFootnote()
 
@@ -24,37 +25,66 @@ def write_dataset(report: Report, dataset: DatasetBase):
     response_units_text = dataset._get_response_units_text()
 
     if dataset.dtype is Dtype.CONTINUOUS:
-        tbl = report.document.add_table(3, dataset.num_dose_groups + 1, style=styles.table)
+        if long:
+            tbl = report.document.add_table(dataset.num_dose_groups + 1, 4, style=styles.table)
 
-        write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
-        write_cell(tbl.cell(1, 0), "N", hdr)
-        write_cell(tbl.cell(2, 0), "Mean ± SD" + response_units_text, hdr)
+            write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
+            write_cell(tbl.cell(0, 1), "N", hdr)
+            write_cell(tbl.cell(0, 2), "Mean" + response_units_text, hdr)
+            write_cell(tbl.cell(0, 3), "Std. Dev." + response_units_text, hdr)
 
-        for i, (dose, n, mean, stdev) in enumerate(
-            zip(dataset.doses, dataset.ns, dataset.means, dataset.stdevs)
-        ):
-            write_cell(tbl.cell(0, i + 1), dose, styles.tbl_body)
-            write_cell(tbl.cell(1, i + 1), n, styles.tbl_body)
-            write_cell(tbl.cell(2, i + 1), f"{mean} ± {stdev}", styles.tbl_body)
+            for i, (dose, n, mean, stdev) in enumerate(
+                zip(dataset.doses, dataset.ns, dataset.means, dataset.stdevs)
+            ):
+                write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 1), n, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 2), mean, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 3), stdev, styles.tbl_body)
+        else:
 
-        for i, col in enumerate(tbl.columns):
-            w = 0.75 if i == 0 else (styles.portrait_width - 0.75) / dataset.num_dose_groups
-            set_column_width(col, w)
+            tbl = report.document.add_table(3, dataset.num_dose_groups + 1, style=styles.table)
+
+            write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
+            write_cell(tbl.cell(1, 0), "N", hdr)
+            write_cell(tbl.cell(2, 0), "Mean ± SD" + response_units_text, hdr)
+
+            for i, (dose, n, mean, stdev) in enumerate(
+                zip(dataset.doses, dataset.ns, dataset.means, dataset.stdevs)
+            ):
+                write_cell(tbl.cell(0, i + 1), dose, styles.tbl_body)
+                write_cell(tbl.cell(1, i + 1), n, styles.tbl_body)
+                write_cell(tbl.cell(2, i + 1), f"{mean} ± {stdev}", styles.tbl_body)
+
+            for i, col in enumerate(tbl.columns):
+                w = 0.75 if i == 0 else (styles.portrait_width - 0.75) / dataset.num_dose_groups
+                set_column_width(col, w)
 
     elif dataset.dtype is Dtype.DICHOTOMOUS or dataset.dtype is Dtype.DICHOTOMOUS_CANCER:
-        tbl = report.document.add_table(2, dataset.num_dose_groups + 1, style=styles.table)
+        if long:
+            tbl = report.document.add_table(dataset.num_dose_groups + 1, 3, style=styles.table)
+            write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
+            write_cell(tbl.cell(0, 1), "N", hdr)
+            write_cell(tbl.cell(0, 2), "Incidence", hdr)
 
-        write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
-        write_cell(tbl.cell(1, 0), "Affected / Total (%)" + response_units_text, hdr)
+            for i, (dose, inc, n) in enumerate(zip(dataset.doses, dataset.incidences, dataset.ns)):
+                write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 1), n, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 2), inc, styles.tbl_body)
+        else:
 
-        for i, (dose, inc, n) in enumerate(zip(dataset.doses, dataset.incidences, dataset.ns)):
-            frac = inc / float(n)
-            write_cell(tbl.cell(0, i + 1), dose, styles.tbl_body)
-            write_cell(tbl.cell(1, i + 1), f"{inc}/{n}\n({frac:.1%})", styles.tbl_body)
+            tbl = report.document.add_table(2, dataset.num_dose_groups + 1, style=styles.table)
 
-        for i, col in enumerate(tbl.columns):
-            w = 0.75 if i == 0 else (styles.portrait_width - 0.75) / dataset.num_dose_groups
-            set_column_width(col, w)
+            write_cell(tbl.cell(0, 0), "Dose" + dose_units_text, hdr)
+            write_cell(tbl.cell(1, 0), "Affected / Total (%)" + response_units_text, hdr)
+
+            for i, (dose, inc, n) in enumerate(zip(dataset.doses, dataset.incidences, dataset.ns)):
+                frac = inc / float(n)
+                write_cell(tbl.cell(0, i + 1), dose, styles.tbl_body)
+                write_cell(tbl.cell(1, i + 1), f"{inc}/{n}\n({frac:.1%})", styles.tbl_body)
+
+            for i, col in enumerate(tbl.columns):
+                w = 0.75 if i == 0 else (styles.portrait_width - 0.75) / dataset.num_dose_groups
+                set_column_width(col, w)
 
     elif dataset.dtype is Dtype.CONTINUOUS_INDIVIDUAL:
         # aggregate responses by unique doses
@@ -67,17 +97,31 @@ def write_dataset(report: Report, dataset: DatasetBase):
             .reset_index()
         )
 
-        # create a table
-        tbl = report.document.add_table(df.shape[0] + 1, 2, style=styles.table)
+        if long:
+            tbl = report.document.add_table(
+                len(dataset.individual_doses) + 1, 2, style=styles.table
+            )
+            # add headers
+            write_cell(tbl.cell(0, 0), "Dose", hdr)
+            write_cell(tbl.cell(0, 1), "Response", hdr)
 
-        # add headers
-        write_cell(tbl.cell(0, 0), "Dose", hdr)
-        write_cell(tbl.cell(0, 1), "Response", hdr)
+            # write data
+            for i, (dose, response) in enumerate(zip(dataset.individual_doses, dataset.responses)):
+                write_cell(tbl.cell(i + 1, 0), dose, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 1), response, styles.tbl_body)
+        else:
 
-        # write data
-        for i, row in df.iterrows():
-            write_cell(tbl.cell(i + 1, 0), row.dose, styles.tbl_body)
-            write_cell(tbl.cell(i + 1, 1), row.response, styles.tbl_body)
+            # create a table
+            tbl = report.document.add_table(df.shape[0] + 1, 2, style=styles.table)
+
+            # add headers
+            write_cell(tbl.cell(0, 0), "Dose", hdr)
+            write_cell(tbl.cell(0, 1), "Response", hdr)
+
+            # write data
+            for i, row in df.iterrows():
+                write_cell(tbl.cell(i + 1, 0), row.dose, styles.tbl_body)
+                write_cell(tbl.cell(i + 1, 1), row.response, styles.tbl_body)
 
     else:
         raise ValueError("Unknown dtype: {dataset.dtype}")
@@ -217,4 +261,5 @@ def write_models(report: Report, session: BmdsSession, header_level: int):
         report.document.add_paragraph(model.name(), header_style)
         if model.has_results:
             report.document.add_paragraph(add_mpl_figure(report.document, model.plot(), 6))
+            report.document.add_paragraph(add_mpl_figure(report.document, model.cdfPlot(), 6))
         report.document.add_paragraph(model.text(), styles.fixed_width)

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -247,7 +247,7 @@ class BmdsSession:
         h2 = report.styles.get_header_style(header_level + 1)
         report.document.add_paragraph("Session results", h1)
         report.document.add_paragraph("Input dataset", h2)
-        reporting.write_dataset(report, self.dataset)
+        reporting.write_dataset_tbl(report, self.dataset)
 
         if self.is_bayesian():
             report.document.add_paragraph("Bayesian Summary", h2)

--- a/bmds/plotting.py
+++ b/bmds/plotting.py
@@ -25,9 +25,6 @@ FAILURE_MESSAGE_FORMAT = dict(
     horizontalalignment="center",
     verticalalignment="center",
 )
-CDF_X_LABEL = "Dose"
-CDF_Y_LABEL = "Percentile"
-CDF_TITLE = "BMD Cumulative distribution function"
 
 
 def create_empty_figure():

--- a/bmds/plotting.py
+++ b/bmds/plotting.py
@@ -25,6 +25,9 @@ FAILURE_MESSAGE_FORMAT = dict(
     horizontalalignment="center",
     verticalalignment="center",
 )
+CDF_X_LABEL = "Dose"
+CDF_Y_LABEL = "Percentile"
+CDF_TITLE = "BMD Cumulative distribution function"
 
 
 def create_empty_figure():


### PR DESCRIPTION
Based on initial reviews of reports, some changes were requested:

1. Adding a CDF plot to word
<img width="680" alt="Screen Shot 2021-10-05 at 3 54 01 PM" src="https://user-images.githubusercontent.com/999952/136093429-e5992edd-155b-4178-bde8-3c18ed4bd86b.png">

2. Change dataset tables from wide to long

We added a `long=True` deafult parameter so you can view either approach.

These are the long (default) tables:

Dichotomous
<img width="868" alt="Screen Shot 2021-10-05 at 3 55 06 PM" src="https://user-images.githubusercontent.com/999952/136093555-98862881-cdcc-4033-9f68-28874baf5f06.png">

Continuous summary
<img width="848" alt="Screen Shot 2021-10-05 at 3 55 27 PM" src="https://user-images.githubusercontent.com/999952/136093595-76b7e940-9805-41e7-8d6b-832f55446f6f.png">

Continuous individual
<img width="251" alt="Screen Shot 2021-10-05 at 3 56 05 PM" src="https://user-images.githubusercontent.com/999952/136093667-733720ae-1e4f-401d-9b19-412352031803.png">

These are the previous table formats, no longer the default, but available with `long=False`:

Dichotomous
<img width="876" alt="Screen Shot 2021-10-05 at 3 56 42 PM" src="https://user-images.githubusercontent.com/999952/136093792-766748cd-dc9f-4fa1-8e39-6abd415e5144.png">

Continuous summary
<img width="862" alt="Screen Shot 2021-10-05 at 3 57 50 PM" src="https://user-images.githubusercontent.com/999952/136093883-4f3fca4d-ed23-43c7-b200-433906d11518.png">

Continuous individual
<img width="873" alt="Screen Shot 2021-10-05 at 3 58 34 PM" src="https://user-images.githubusercontent.com/999952/136093971-26b54795-d6d9-4508-983d-65a434d73115.png">

