### PR TITLE
Versions

### DIFF
--- a/bmds/bmds2/sessions.py
+++ b/bmds/bmds2/sessions.py
@@ -351,7 +351,7 @@ class BMDS:
 
 class BMDS_v270(BMDS):
     version_str = constants.BMDS270
-    version_pretty = "BMDS v2.7.0"
+    version_pretty = "2.7.0"
     version_tuple = (2, 7, 0)
     model_options = {
         constants.DICHOTOMOUS: {

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -9,8 +9,7 @@ import numpy.typing as npt
 import pandas as pd
 from simple_settings import settings
 
-from .. import constants
-from .. import __version__
+from .. import __version__, constants
 from ..datasets import DatasetSchemaBase, DatasetType
 from ..reporting.styling import Report
 from ..utils import citation

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -10,6 +10,7 @@ import pandas as pd
 from simple_settings import settings
 
 from .. import constants
+from .. import __version__
 from ..datasets import DatasetSchemaBase, DatasetType
 from ..reporting.styling import Report
 from ..utils import citation
@@ -349,6 +350,8 @@ class Bmds330(BmdsSession):
                 string=self.version_str,
                 pretty=self.version_pretty,
                 numeric=self.version_tuple,
+                python=__version__,
+                dll=self.dll_version(),
             ),
             dataset=self.dataset.serialize(),
             models=[model.serialize() for model in self.models],

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -308,7 +308,7 @@ class BmdsSession:
 
 class Bmds330(BmdsSession):
     version_str = constants.BMDS330
-    version_pretty = "BMDS v3.3.0"
+    version_pretty = "3.3.0"
     version_tuple = (3, 3, 0)
     model_options = {
         constants.DICHOTOMOUS: {

--- a/bmds/bmds3/types/sessions.py
+++ b/bmds/bmds3/types/sessions.py
@@ -12,6 +12,8 @@ class VersionSchema(BaseModel):
     string: str
     pretty: str
     numeric: Tuple[int, ...]
+    python: str
+    dll: str
 
 
 class SessionSchemaBase(BaseModel):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,13 +1,13 @@
 # build
-wheel==0.36.2
+wheel==0.37.1
 
 # docs
 Sphinx==4.0.3
 
 # tests
-pytest==6.2.4
-pytest-mpl==0.13
-vcrpy==4.1.1
+pytest==7.1.2
+pytest-mpl==0.16.1
+vcrpy==4.2.0
 pytest-vcr==1.0.2
 
 # lint and formatting tools

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,10 +11,10 @@ vcrpy==4.2.0
 pytest-vcr==1.0.2
 
 # lint and formatting tools
-black==22.3.0
-flake8==3.9.2
-flake8-isort==4.0.0
-isort==5.9.1
+black==22.6.0
+flake8==4.0.1
+flake8-isort==4.1.2.post0
+isort==5.10.1
 
 # install bmds in editable mode
 -e .


### PR DESCRIPTION
- Add python package and dll version to the VersionSchema version schema
- Change "pretty" version of BMDS version to not include BMDS

A default version:

```python
{
  'string': 'BMDS330',
  'pretty': '3.3.0',
  'numeric': (3, 3, 0),
  'python': '1.0.0.dev',
  'dll': '2022.05'
}
```

Bonus:

- Update packages for development environment