### PR TITLE
fix multistage/polynomial background term name

### DIFF
--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -236,6 +236,7 @@ class Polynomial(BmdModelContinuous):
     def get_param_names(self) -> List[str]:
         names = [f"b{i}" for i in range(self.settings.degree + 1)]
         names.extend(self.get_variance_param_names())
+        names[0] = "g"
         return names
 
 

--- a/bmds/bmds3/models/dichotomous.py
+++ b/bmds/bmds3/models/dichotomous.py
@@ -221,7 +221,9 @@ class Multistage(BmdModelDichotomous):
         return g + (1 - g) * (1 - np.exp(-1.0 * val))
 
     def get_param_names(self) -> List[str]:
-        return [f"b{i}" for i in range(self.settings.degree + 1)]
+        names = [f"b{i}" for i in range(self.settings.degree + 1)]
+        names[0] = "g"
+        return names
 
 
 bmd_model_map = {

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -232,6 +232,10 @@ class ContinuousParameters(BaseModel):
         param_names = model.get_param_names()
         priors = cls.get_priors(model)
 
+        cov_n = result.initial_n
+        cov = result.np_cov.reshape(result.initial_n, result.initial_n)
+        slice = None
+
         # DLL deletes the c parameter and shifts items down; correct in outputs here
         if model.bmd_model_class.id == constants.ContinuousModelIds.c_exp_m3:
 
@@ -247,16 +251,17 @@ class ContinuousParameters(BaseModel):
             # reshape covariance
             cov_n = result.initial_n - 1
             cov = result.np_cov[: cov_n * cov_n].reshape(cov_n, cov_n)
-        else:
-            cov_n = result.initial_n
-            cov = result.np_cov.reshape(result.initial_n, result.initial_n)
+
+            # change slice for other variables
+            slice = -1
+
         return cls(
             names=param_names,
-            values=result.np_parms[:-1],
-            bounded=summary.np_bounded[:-1],
-            se=summary.np_stdErr[:-1],
-            lower_ci=summary.np_lowerConf[:-1],
-            upper_ci=summary.np_upperConf[:-1],
+            values=result.np_parms[:slice],
+            bounded=summary.np_bounded[:slice],
+            se=summary.np_stdErr[:slice],
+            lower_ci=summary.np_lowerConf[:slice],
+            upper_ci=summary.np_upperConf[:slice],
             cov=cov,
             prior_type=priors[0],
             prior_initial_value=priors[1],

--- a/tests/bmds3/models/test_continuous.py
+++ b/tests/bmds3/models/test_continuous.py
@@ -71,15 +71,15 @@ class TestBmdModelContinuous:
 
         # test polynomial
         model = continuous.Linear(dataset=cdataset2)
-        assert model.get_param_names() == ["b0", "b1", "alpha"]
+        assert model.get_param_names() == ["g", "b1", "alpha"]
         model = continuous.Polynomial(dataset=cdataset2)
-        assert model.get_param_names() == ["b0", "b1", "b2", "alpha"]
+        assert model.get_param_names() == ["g", "b1", "b2", "alpha"]
         model = continuous.Polynomial(dataset=cdataset2, settings=dict(degree=3))
-        assert model.get_param_names() == ["b0", "b1", "b2", "b3", "alpha"]
+        assert model.get_param_names() == ["g", "b1", "b2", "b3", "alpha"]
         model = continuous.Polynomial(
             dataset=cdataset2, settings=dict(degree=3, disttype=DistType.normal_ncv)
         )
-        assert model.get_param_names() == ["b0", "b1", "b2", "b3", "rho", "alpha"]
+        assert model.get_param_names() == ["g", "b1", "b2", "b3", "rho", "alpha"]
 
     @pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
     def test_report(self, cdataset2):

--- a/tests/bmds3/models/test_dichotmous.py
+++ b/tests/bmds3/models/test_dichotmous.py
@@ -19,9 +19,9 @@ class TestBmdModelDichotomous:
 
         # test multistage
         model = dichotomous.Multistage(dataset=ddataset2)
-        assert model.get_param_names() == ["b0", "b1", "b2"]
+        assert model.get_param_names() == ["g", "b1", "b2"]
         model = dichotomous.Multistage(dataset=ddataset2, settings=dict(degree=3))
-        assert model.get_param_names() == ["b0", "b1", "b2", "b3"]
+        assert model.get_param_names() == ["g", "b1", "b2", "b3"]
 
     def test_default_prior_class(self, ddataset2):
         for Model, prior_class in [


### PR DESCRIPTION
Rename the `b0` parameter to `g` for the multistage, polynomial, and linear models to be consistent with the model equation parameters.

Also fix a bug from #78 where we were always dropping the highest parameter value for non exponential M3 models.
