### PR TITLE
Update bmd visuals

### DIFF
--- a/bmds/plotting.py
+++ b/bmds/plotting.py
@@ -20,10 +20,10 @@ BMD_LINE_FORMAT = dict(
     c="#6470C0",
     markeredgecolor="white",
     markeredgewidth=2,
-    fmt="d",
-    ecolor=to_rgba("#6470C0", 0.7),
-    ms=12,
-    elinewidth=7,
+    fmt="o",
+    ecolor=to_rgba("#6470C0", 0.6),
+    ms=10,
+    elinewidth=15,
     zorder=150,
 )
 FAILURE_MESSAGE_FORMAT = dict(


### PR DESCRIPTION
Update visuals to change diamonds to thicker bars. Inspired from these excellent [538](https://projects.fivethirtyeight.com/2022-election-forecast/senate/?cid=rrpromo) visuals.

Old:
![image](https://user-images.githubusercontent.com/999952/185819297-b14969c1-9ac1-4d47-94fa-df7231e2c86b.png)

New:
![image](https://user-images.githubusercontent.com/999952/185819312-cb4e59de-fbdb-470e-98d2-0a2db1c207ba.png)


The 538 visual:
![image](https://user-images.githubusercontent.com/999952/185819212-ddfb2479-76e7-4b54-a399-2ff36d135ba5.png)