### PR TITLE
update test environments to py311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: ["3.11"]
         os: ["ubuntu-22.04", "windows-2022"]
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 mkdocs:
   configuration: docs/mkdocs.yml
 python:


### PR DESCRIPTION
Don't drop support for python 3.9 or 3.10, but run python 3.11 in github actions.