### PR TITLE
Remove PriorClass.custom

### DIFF
--- a/bmds/bmds3/batch.py
+++ b/bmds/bmds3/batch.py
@@ -58,15 +58,14 @@ class BmdsSessionBatch:
 
     def to_excel(self, path: Optional[Path] = None) -> Union[Path, BytesIO]:
         f: Union[Path, BytesIO] = path or BytesIO()
-        writer = pd.ExcelWriter(f)
-        data = {
-            "summary": self.df_summary(),
-            "datasets": self.df_dataset(),
-            "parameters": self.df_params(),
-        }
-        for name, df in data.items():
-            df.to_excel(writer, sheet_name=name, index=False)
-        writer.save()
+        with pd.ExcelWriter(f) as writer:
+            data = {
+                "summary": self.df_summary(),
+                "datasets": self.df_dataset(),
+                "parameters": self.df_params(),
+            }
+            for name, df in data.items():
+                df.to_excel(writer, sheet_name=name, index=False)
         return f
 
     def to_docx(

--- a/bmds/bmds3/constants.py
+++ b/bmds/bmds3/constants.py
@@ -178,7 +178,6 @@ class PriorClass(IntEnum):
     frequentist_unrestricted = 0
     frequentist_restricted = 1
     bayesian = 2
-    custom = 3
 
     @property
     def name(self) -> str:
@@ -190,8 +189,6 @@ class PriorClass(IntEnum):
 
     @property
     def is_bayesian(self) -> bool:
-        if self == self.custom:
-            raise ValueError("Cannot determine")
         return self == self.bayesian
 
 

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -150,13 +150,8 @@ class BmdsSession:
         self.recommend()
 
     def is_bayesian(self) -> bool:
-        """Determine if models are using a bayesian or frequentist approach.
-
-        Looks at the first model's prior to determine if it's bayesian, else assume frequentist.
-        """
-        # TODO - fix with handle PriorClass.custom, perhaps if any type is != 0?
-        first_class = self.models[0].settings.priors.prior_class
-        return first_class is PriorClass.bayesian
+        """Determine if models are using a bayesian or frequentist approach."""
+        return self.models[0].settings.priors.is_bayesian
 
     def citation(self) -> dict:
         return citation(self.dll_version())

--- a/bmds/bmds3/types/priors.py
+++ b/bmds/bmds3/types/priors.py
@@ -91,10 +91,7 @@ class ModelPriors(BaseModel):
 
     @property
     def is_bayesian(self) -> bool:
-        try:
-            return self.prior_class.is_bayesian
-        except ValueError:
-            raise NotImplementedError("Handle custom case")
+        return self.prior_class.is_bayesian
 
 
 # lazy mapping; saves copy as requested


### PR DESCRIPTION
Remove custom prior class since we cannot distinguish if it is frequentist or bayesian. In the future we could re-evaluate, or potentially add two custom classes for a custom frequentist and a custom bayesian should there be a need.