### PR TITLE
typing; update to py3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,6 @@ BMDS Python interface
    :target: https://zenodo.org/badge/latestdoi/61229626
 
 This Python package is designed to run the `USEPA BMDS`_ software from a python
-interface. It requires Python3.9+.
+interface. It requires Python3.11+.
 
 .. _`USEPA BMDS`: https://www.epa.gov/bmds

--- a/bmds/benchmarks/analyses.py
+++ b/bmds/benchmarks/analyses.py
@@ -1,5 +1,5 @@
 import abc
-from enum import IntEnum
+from enum import Enum
 
 from ..constants import Dtype, Version
 from .datasets import BenchmarkDataset
@@ -88,7 +88,7 @@ class FitContinuousAnalysis(Analysis):
         bulk_save_models(self.key, results)
 
 
-class BenchmarkAnalyses(IntEnum):
+class BenchmarkAnalyses(Enum):
     """
     A specific type of BMDS analysis that can be conducted
     """

--- a/bmds/benchmarks/analyses.py
+++ b/bmds/benchmarks/analyses.py
@@ -1,5 +1,5 @@
 import abc
-from enum import Enum
+from enum import IntEnum
 
 from ..constants import Dtype, Version
 from .datasets import BenchmarkDataset
@@ -88,7 +88,7 @@ class FitContinuousAnalysis(Analysis):
         bulk_save_models(self.key, results)
 
 
-class BenchmarkAnalyses(Enum):
+class BenchmarkAnalyses(IntEnum):
     """
     A specific type of BMDS analysis that can be conducted
     """

--- a/bmds/benchmarks/datasets.py
+++ b/bmds/benchmarks/datasets.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import Enum
 from typing import NamedTuple
 
 import pandas as pd
@@ -13,7 +13,7 @@ class BenchmarkDatasetMetadata(NamedTuple):
     dataset_key: str
 
 
-class BenchmarkDataset(StrEnum):
+class BenchmarkDataset(Enum):
     """A benchmark dataset that can be used in to run an analysis"""
 
     TOXREFDB_V2 = (

--- a/bmds/benchmarks/datasets.py
+++ b/bmds/benchmarks/datasets.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import NamedTuple
 
 import pandas as pd
@@ -13,7 +13,7 @@ class BenchmarkDatasetMetadata(NamedTuple):
     dataset_key: str
 
 
-class BenchmarkDataset(Enum):
+class BenchmarkDataset(StrEnum):
     """A benchmark dataset that can be used in to run an analysis"""
 
     TOXREFDB_V2 = (

--- a/bmds/benchmarks/executors/model_fit.py
+++ b/bmds/benchmarks/executors/model_fit.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ... import constants
 from ...bmds2.models import continuous as c2
 from ...bmds2.models import dichotomous as d2
@@ -10,7 +8,7 @@ from ..models import ModelResult
 from .shared import nan_to_default
 
 
-def build_jobs(datasets, version: constants.Version, dtype: constants.Dtype) -> List:
+def build_jobs(datasets, version: constants.Version, dtype: constants.Dtype) -> list:
     check = (version, dtype)
     if check == (constants.Version.BMDS270, constants.Dtype.CONTINUOUS):
         models = (

--- a/bmds/benchmarks/executors/shared.py
+++ b/bmds/benchmarks/executors/shared.py
@@ -1,6 +1,6 @@
 import os
 from concurrent.futures import ProcessPoolExecutor
-from typing import Callable, List
+from typing import Callable
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -15,15 +15,15 @@ def nan_to_default(val) -> float:
     return BMDS_BLANK_VALUE if isinstance(val, str) or np.isnan(val) else val
 
 
-def multiprocess(jobs: List, run: Callable) -> List:
+def multiprocess(jobs: list, run: Callable) -> list:
     """Run a list of jobs in multiprocessing
 
     Args:
-        jobs (List): A list of jobs
+        jobs (list): A list of jobs
         run (Callable): A callable executor
 
     Returns:
-        List: A list of results
+        list: A list of results
     """
     nprocs = max(os.cpu_count() - 1, 1)
     results = []

--- a/bmds/bmds2/exports.py
+++ b/bmds/bmds2/exports.py
@@ -1,7 +1,4 @@
-from typing import Dict, List
-
-
-def df_ordered_dict(include_io=True) -> Dict[str, List]:
+def df_ordered_dict(include_io=True) -> dict[str, list]:
     """
     Return an ordered defaultdict designed to create tabular exports from datasets
     """

--- a/bmds/bmds2/sessions.py
+++ b/bmds/bmds2/sessions.py
@@ -3,7 +3,6 @@ import os
 import platform
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from typing import Dict, Tuple
 
 import pandas as pd
 from simple_settings import settings
@@ -22,8 +21,8 @@ class BMDS:
 
     version_str: str = ""
     version_pretty: str = ""
-    version_tuple: Tuple[int, ...] = ()
-    model_options: Dict[str, Dict] = {}
+    version_tuple: tuple[int, ...] = ()
+    model_options: dict[str, dict] = {}
 
     bmr_options = {
         constants.DICHOTOMOUS: constants.DICHOTOMOUS_BMRS,
@@ -36,11 +35,11 @@ class BMDS:
         """
         Attributes:
             dtype (str): dataset type
-            models (List[Models]): list of BMDS models to be included
+            models (list[Models]): list of BMDS models to be included
             dataset (Dataset): A BMDS dataset, mutable if doses are dropped
             original_dataset (Dataset): The unchanged original dataset.
             doses_dropped (int): the number of doses dropped in current session
-            doses_dropped_sessions (Dict[int, Session): history of prior sessions
+            doses_dropped_sessions (dict[int, Session): history of prior sessions
         """
         self.dtype = dtype
         if self.dtype not in constants.DTYPES:

--- a/bmds/bmds3/batch.py
+++ b/bmds/bmds3/batch.py
@@ -4,7 +4,7 @@ import zipfile
 from concurrent.futures import ProcessPoolExecutor
 from io import BytesIO
 from pathlib import Path
-from typing import Callable, List, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple, Optional, Self, Union
 
 import pandas as pd
 from tqdm import tqdm
@@ -21,10 +21,10 @@ class ExecutionResponse(NamedTuple):
 
 
 class BmdsSessionBatch:
-    def __init__(self, sessions: Optional[List[BmdsSession]] = None):
+    def __init__(self, sessions: Optional[list[BmdsSession]] = None):
         if sessions is None:
             sessions = []
-        self.sessions: List[BmdsSession] = sessions
+        self.sessions: list[BmdsSession] = sessions
         self.errors = []
 
     def df_summary(self) -> pd.DataFrame:
@@ -123,12 +123,12 @@ class BmdsSessionBatch:
 
     @classmethod
     def execute(
-        cls, datasets: List[DatasetBase], runner: Callable, nprocs: Optional[int] = None
-    ) -> "BmdsSessionBatch":
+        cls, datasets: list[DatasetBase], runner: Callable, nprocs: Optional[int] = None
+    ) -> Self:
         """Execute sessions using multiple processors.
 
         Args:
-            datasets (List[DatasetBase]): The datasets to execute
+            datasets (list[DatasetBase]): The datasets to execute
             runner (Callable[dataset] -> ExecutionResponse): The method which executes a session
             nprocs (Optional[int]): the number of processors to use; defaults to N-1. If 1 is
                 specified; the batch session is called linearly without a process pool
@@ -139,7 +139,7 @@ class BmdsSessionBatch:
         if nprocs is None:
             nprocs = max(os.cpu_count() - 1, 1)
 
-        results: List[ExecutionResponse] = []
+        results: list[ExecutionResponse] = []
         if nprocs == 1:
             # run without a ProcessPoolExecutor; useful for debugging
             for dataset in tqdm(datasets, desc="Executing..."):
@@ -172,7 +172,7 @@ class BmdsSessionBatch:
         return batch
 
     @classmethod
-    def deserialize(cls, data: str) -> "BmdsSessionBatch":
+    def deserialize(cls, data: str) -> Self:
         """Load serialized batch export into a batch session.
 
         Args:
@@ -183,7 +183,7 @@ class BmdsSessionBatch:
         return BmdsSessionBatch(sessions=sessions)
 
     @classmethod
-    def load(cls, archive: Path) -> "BmdsSessionBatch":
+    def load(cls, archive: Path) -> Self:
         """Load a BmdsSession from a compressed zipfile
 
         Args:

--- a/bmds/bmds3/batch.py
+++ b/bmds/bmds3/batch.py
@@ -4,7 +4,7 @@ import zipfile
 from concurrent.futures import ProcessPoolExecutor
 from io import BytesIO
 from pathlib import Path
-from typing import Callable, NamedTuple, Optional, Self, Union
+from typing import Callable, NamedTuple, Optional, Self
 
 import pandas as pd
 from tqdm import tqdm
@@ -17,7 +17,7 @@ from .sessions import BmdsSession
 
 class ExecutionResponse(NamedTuple):
     success: bool
-    content: Union[dict, list[dict]]
+    content: dict | list[dict]
 
 
 class BmdsSessionBatch:
@@ -56,8 +56,8 @@ class BmdsSessionBatch:
                     )
         return pd.DataFrame(data=data)
 
-    def to_excel(self, path: Optional[Path] = None) -> Union[Path, BytesIO]:
-        f: Union[Path, BytesIO] = path or BytesIO()
+    def to_excel(self, path: Optional[Path] = None) -> Path | BytesIO:
+        f: Path | BytesIO = path or BytesIO()
         with pd.ExcelWriter(f) as writer:
             data = {
                 "summary": self.df_summary(),

--- a/bmds/bmds3/constants.py
+++ b/bmds/bmds3/constants.py
@@ -1,5 +1,4 @@
 from enum import Enum, IntEnum
-from typing import Tuple
 
 from pydantic import BaseModel
 
@@ -15,7 +14,7 @@ class BmdModelSchema(BaseModel):
 
 
 class DichotomousModel(BmdModelSchema):
-    params: Tuple[str, ...]
+    params: tuple[str, ...]
 
     @property
     def num_params(self):
@@ -92,8 +91,8 @@ class DichotomousModelChoices(Enum):
 
 
 class ContinuousModel(BmdModelSchema):
-    params: Tuple[str, ...]
-    variance_params: Tuple[str, ...]
+    params: tuple[str, ...]
+    variance_params: tuple[str, ...]
 
 
 class ContinuousModelIds(IntEnum):

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -4,7 +4,7 @@ import abc
 import ctypes
 import logging
 import platform
-from typing import TYPE_CHECKING, NamedTuple, Optional, Self, Union
+from typing import TYPE_CHECKING, NamedTuple, Optional, Self
 
 from pydantic import BaseModel
 
@@ -74,7 +74,7 @@ class BmdsLibraryManager:
         return dll
 
 
-InputModelSettings = Optional[Union[dict, BaseModel]]
+InputModelSettings = dict | BaseModel | None
 
 
 class BmdModel(abc.ABC):

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -4,7 +4,7 @@ import abc
 import ctypes
 import logging
 import platform
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, NamedTuple, Optional, Self, Union
 
 from pydantic import BaseModel
 
@@ -30,7 +30,7 @@ class BmdsLibraryManager:
     def __init__(self):
         raise RuntimeError("Use as a static-class")
 
-    _dll_cache: Dict[str, ctypes.CDLL] = {}
+    _dll_cache: dict[str, ctypes.CDLL] = {}
 
     @classmethod
     def get_dll(cls, bmds_version: str, base_name: str) -> ctypes.CDLL:
@@ -74,7 +74,7 @@ class BmdsLibraryManager:
         return dll
 
 
-InputModelSettings = Optional[Union[Dict, BaseModel]]
+InputModelSettings = Optional[Union[dict, BaseModel]]
 
 
 class BmdModel(abc.ABC):
@@ -195,14 +195,14 @@ class BmdModel(abc.ABC):
         return fig
 
     @abc.abstractmethod
-    def get_param_names(self) -> List[str]:
+    def get_param_names(self) -> list[str]:
         ...
 
     @abc.abstractmethod
     def get_priors_list(self) -> list[list]:
         ...
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         return self.serialize().dict()
 
     @abc.abstractmethod
@@ -212,7 +212,7 @@ class BmdModel(abc.ABC):
 
 class BmdModelSchema(BaseModel):
     @classmethod
-    def get_subclass(cls, dtype: Dtype) -> "BmdModelSchema":
+    def get_subclass(cls, dtype: Dtype) -> Self:
         from .continuous import BmdModelContinuousSchema
         from .dichotomous import BmdModelDichotomousSchema
 
@@ -235,7 +235,7 @@ class BmdModelAveraging(abc.ABC):
     def __init__(
         self,
         session: BmdsSession,
-        models: List[BmdModel],
+        models: list[BmdModel],
         settings: InputModelSettings = None,
     ):
         self.session = session
@@ -271,13 +271,13 @@ class BmdModelAveraging(abc.ABC):
     def plot(self):
         ...
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         return self.serialize.dict()
 
 
 class BmdModelAveragingSchema(BaseModel):
     @classmethod
-    def get_subclass(cls, dtype: Dtype) -> "BmdModelAveragingSchema":
+    def get_subclass(cls, dtype: Dtype) -> Self:
         from .ma import BmdModelAveragingDichotomousSchema
 
         if dtype in (Dtype.DICHOTOMOUS, Dtype.DICHOTOMOUS_CANCER):

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import List, Optional, Type
+from typing import Optional, Type
 
 import numpy as np
 
@@ -98,7 +98,7 @@ class BmdModelContinuous(BmdModel):
             results=self.results,
         )
 
-    def get_param_names(self) -> List[str]:
+    def get_param_names(self) -> list[str]:
         names = list(self.bmd_model_class.params)
         names.extend(self.get_variance_param_names())
         return names
@@ -214,7 +214,7 @@ class Polynomial(BmdModelContinuous):
             val += params[i] * doses**i
         return val
 
-    def get_param_names(self) -> List[str]:
+    def get_param_names(self) -> list[str]:
         names = [f"b{i}" for i in range(self.settings.degree + 1)]
         names.extend(self.get_variance_param_names())
         names[0] = "g"

--- a/bmds/bmds3/models/dichotomous.py
+++ b/bmds/bmds3/models/dichotomous.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 from scipy.stats import gamma, norm
@@ -72,7 +72,7 @@ class BmdModelDichotomous(BmdModel):
     def get_default_prior_class(self) -> PriorClass:
         return PriorClass.frequentist_restricted
 
-    def get_param_names(self) -> List[str]:
+    def get_param_names(self) -> list[str]:
         names = list(self.bmd_model_class.params)
         return names
 
@@ -221,7 +221,7 @@ class Multistage(BmdModelDichotomous):
             val += params[i] * doses**i
         return g + (1 - g) * (1 - np.exp(-1.0 * val))
 
-    def get_param_names(self) -> List[str]:
+    def get_param_names(self) -> list[str]:
         names = [f"b{i}" for i in range(self.settings.degree + 1)]
         names[0] = "g"
         return names

--- a/bmds/bmds3/models/ma.py
+++ b/bmds/bmds3/models/ma.py
@@ -1,6 +1,5 @@
 import ctypes
 from itertools import cycle
-from typing import List
 
 from ... import plotting
 from ..types.dichotomous import DichotomousModelSettings
@@ -102,7 +101,7 @@ class BmdModelAveragingDichotomous(BmdModelAveraging):
 class BmdModelAveragingDichotomousSchema(BmdModelAveragingSchema):
     settings: DichotomousModelSettings
     results: DichotomousModelAverageResult
-    model_indexes: List[int]
+    model_indexes: list[int]
 
     def deserialize(self, session) -> BmdModelAveragingDichotomous:
         models = [session.models[idx] for idx in self.model_indexes]

--- a/bmds/bmds3/recommender/checks.py
+++ b/bmds/bmds3/recommender/checks.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional, Union
+from typing import Any, Optional, Self, Union
 
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ class CheckResponse(BaseModel):
     message: str
 
     @classmethod
-    def success(cls) -> "CheckResponse":
+    def success(cls) -> Self:
         return CheckResponse(logic_bin=constants.LogicBin.NO_CHANGE, message="")
 
 

--- a/bmds/bmds3/recommender/checks.py
+++ b/bmds/bmds3/recommender/checks.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional, Self, Union
+from typing import Any, Optional, Self
 
 from pydantic import BaseModel
 
@@ -7,7 +7,7 @@ from ... import constants
 from ..constants import BMDS_BLANK_VALUE, DistType
 from .constants import RuleClass
 
-Number = Union[float, int]
+Number = float | int
 
 
 class CheckResponse(BaseModel):

--- a/bmds/bmds3/recommender/constants.py
+++ b/bmds/bmds3/recommender/constants.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class RuleClass(str, Enum):
+class RuleClass(StrEnum):
     gof = "gof"
     dof_zero = "dof_zero"
     high_bmd = "high_bmd"

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -1,6 +1,6 @@
 import itertools
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional, Self
 
 import numpy as np
 import pandas as pd
@@ -43,7 +43,7 @@ class RecommenderSettings(BaseModel):
     recommend_questionable: bool = False
     recommend_viable: bool = True
     sufficiently_close_bmdl: float = 3
-    rules: List[Rule]
+    rules: list[Rule]
 
     _default: Optional[str] = None
 
@@ -57,7 +57,7 @@ class RecommenderSettings(BaseModel):
         return rules
 
     @classmethod
-    def build_default(cls) -> "RecommenderSettings":
+    def build_default(cls) -> Self:
         if cls._default is None:
             path = Path(__file__).parent / "default.json"
             cls._default = path.read_text()
@@ -81,8 +81,8 @@ class RecommenderSettings(BaseModel):
 class RecommenderResults(BaseModel):
     recommended_model_index: Optional[int]
     recommended_model_variable: Optional[str]
-    model_bin: List[LogicBin] = []
-    model_notes: List[Dict[int, List[str]]] = []
+    model_bin: list[LogicBin] = []
+    model_notes: list[dict[int, list[str]]] = []
 
     def bin_text(self, index: int) -> str:
         if self.recommended_model_index == index:
@@ -126,7 +126,7 @@ class Recommender:
         self.settings: RecommenderSettings = settings
         self.results: Optional[RecommenderResults] = None
 
-    def recommend(self, dataset: DatasetBase, models: List[BmdModel]):
+    def recommend(self, dataset: DatasetBase, models: list[BmdModel]):
         self.results = RecommenderResults()
 
         if not self.settings.enabled:
@@ -138,7 +138,7 @@ class Recommender:
         for model in models:
             # set defaults
             current_bin = LogicBin.NO_CHANGE
-            notes: Dict[int, List[str]] = {
+            notes: dict[int, list[str]] = {
                 LogicBin.NO_CHANGE: [],
                 LogicBin.WARNING: [],
                 LogicBin.FAILURE: [],
@@ -189,12 +189,12 @@ class Recommender:
         model = self._get_parsimonious_model(model_subset)
         self.results.recommended_model_index = models.index(model)
 
-    def _get_bmdl_ratio(self, models: List[BmdModel]) -> float:
+    def _get_bmdl_ratio(self, models: list[BmdModel]) -> float:
         """Return BMDL ratio in list of models."""
         bmdls = [model.results.bmdl for model in models if model.results.bmdl > 0]
         return max(bmdls) / min(bmdls)
 
-    def _get_recommended_models(self, models: List[BmdModel], field: str) -> List[BmdModel]:
+    def _get_recommended_models(self, models: list[BmdModel], field: str) -> list[BmdModel]:
         """
         Returns a list of models which have the minimum target field value
         for a given field name (AIC or BMDL).
@@ -209,7 +209,7 @@ class Recommender:
         matches = np.where(values == values.min())[0].tolist()
         return [models[i] for i in matches]
 
-    def _get_parsimonious_model(self, models: List[BmdModel]) -> BmdModel:
+    def _get_parsimonious_model(self, models: list[BmdModel]) -> BmdModel:
         """
         Return the most parsimonious model of all available models. The most
         parsimonious model is defined as the model with the fewest number of

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from copy import copy, deepcopy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -38,8 +38,8 @@ class BmdsSession:
 
     version_str: str
     version_pretty: str
-    version_tuple: Tuple[int, ...]
-    model_options: Dict[str, Dict]
+    version_tuple: tuple[int, ...]
+    model_options: dict[str, dict]
 
     def __init__(
         self,
@@ -47,14 +47,14 @@ class BmdsSession:
         recommendation_settings: Optional[RecommenderSettings] = None,
     ):
         self.dataset = dataset
-        self.models: List[BmdModel] = []
+        self.models: list[BmdModel] = []
         self.ma_weights: Optional[npt.NDArray] = None
         self.model_average: Optional[BmdModelAveraging] = None
         self.recommendation_settings: Optional[RecommenderSettings] = recommendation_settings
         self.recommender: Optional[Recommender] = None
         self.selected: SelectedModel = SelectedModel(self)
 
-    def add_default_bayesian_models(self, global_settings: Dict = None, model_average: bool = True):
+    def add_default_bayesian_models(self, global_settings: dict = None, model_average: bool = True):
         global_settings = deepcopy(global_settings) if global_settings else {}
         global_settings["priors"] = PriorClass.bayesian
         for name in self.model_options[self.dataset.dtype].keys():
@@ -96,7 +96,7 @@ class BmdsSession:
         weights = np.array(weights)
         self.ma_weights = weights / weights.sum()
 
-    def add_model_averaging(self, weights: Optional[List[float]] = None):
+    def add_model_averaging(self, weights: Optional[list[float]] = None):
         """
         Must be added average other models are added since a shallow copy is taken, and the
         execution of model averaging assumes all other models were executed.
@@ -168,7 +168,7 @@ class BmdsSession:
         return get_version(dll)
 
     @classmethod
-    def from_serialized(cls, data: Dict) -> BmdsSession:
+    def from_serialized(cls, data: dict) -> BmdsSession:
         try:
             version = data["version"]["numeric"]
             dtype = data["dataset"]["dtype"]

--- a/bmds/bmds3/types/common.py
+++ b/bmds/bmds3/types/common.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 
 from ..constants import BMDS_BLANK_VALUE
 
 
-def list_t_c(list: List[Any], ctype):
+def list_t_c(list: list[Any], ctype):
     return (ctype * len(list))(*list)
 
 
-def residual_of_interest(bmd: float, doses: List[float], residuals: List[float]) -> float:
+def residual_of_interest(bmd: float, doses: list[float], residuals: list[float]) -> float:
     if bmd <= 0:
         return BMDS_BLANK_VALUE
     diffs = [abs(bmd - dose) for dose in doses]
@@ -34,7 +34,7 @@ class PydanticNumpyArray(np.ndarray):
         yield cls.validate
 
     @classmethod
-    def listify(cls, dict_: Dict):
+    def listify(cls, dict_: dict):
         # convert numpy arrays to lists which can be json serialized
         for key, value in dict_.items():
             if isinstance(value, np.ndarray):

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -1,6 +1,6 @@
 import ctypes
 from enum import IntEnum
-from typing import Dict, List, Optional, Union
+from typing import Optional, Self, Union
 
 import numpy as np
 import pandas as pd
@@ -212,7 +212,7 @@ class ContinuousModelResult(BaseModel):
     bmd_dist: NumpyFloatArray
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousModelResult":
+    def from_model(cls, model) -> Self:
         summary = model.structs.summary
         result = model.structs.result
         arr = result.np_bmd_dist.reshape(2, result.dist_numE)
@@ -230,13 +230,13 @@ class ContinuousModelResult(BaseModel):
             bmd_dist=arr,
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
 
 class ContinuousParameters(BaseModel):
-    names: List[str]
+    names: list[str]
     values: NumpyFloatArray
     se: NumpyFloatArray
     lower_ci: NumpyFloatArray
@@ -255,7 +255,7 @@ class ContinuousParameters(BaseModel):
         return np.array(priors_list, dtype=np.float64).T
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousParameters":
+    def from_model(cls, model) -> Self:
         result = model.structs.result
         summary = model.structs.summary
         param_names = model.get_param_names()
@@ -299,7 +299,7 @@ class ContinuousParameters(BaseModel):
             prior_max_value=priors[4],
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
@@ -331,7 +331,7 @@ class ContinuousParameters(BaseModel):
         df.style.background_gradient(cmap="viridis")
         return df
 
-    def rows(self, extras: Dict) -> List[Dict]:
+    def rows(self, extras: dict) -> list[dict]:
         rows = []
         for i in range(len(self.names)):
             rows.append(
@@ -370,7 +370,7 @@ class ContinuousGof(BaseModel):
     roi: float
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousGof":
+    def from_model(cls, model) -> Self:
         gof = model.structs.gof
         # only keep indexes where the num ob obsMean + obsSD == 0;
         # needed for continuous individual datasets where individual items are collapsed into groups
@@ -392,7 +392,7 @@ class ContinuousGof(BaseModel):
             ),
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
@@ -436,13 +436,13 @@ class ContinuousGof(BaseModel):
 
 
 class ContinuousDeviance(BaseModel):
-    names: List[str]
-    loglikelihoods: List[float]
-    num_params: List[int]
-    aics: List[float]
+    names: list[str]
+    loglikelihoods: list[float]
+    num_params: list[int]
+    aics: list[float]
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousDeviance":
+    def from_model(cls, model) -> Self:
         aod = model.structs.aod
         return cls(
             names=["A1", "A2", "A3", "fitted", "reduced"],
@@ -462,13 +462,13 @@ class ContinuousDeviance(BaseModel):
 
 
 class ContinuousTests(BaseModel):
-    names: List[str]
-    ll_ratios: List[float]
-    dfs: List[float]
-    p_values: List[float]
+    names: list[str]
+    ll_ratios: list[float]
+    dfs: list[float]
+    p_values: list[float]
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousTests":
+    def from_model(cls, model) -> Self:
         tests = model.structs.aod.toi_struct
         return cls(
             names=["Test 1", "Test 2", "Test 3", "Test 4"],
@@ -495,7 +495,7 @@ class ContinuousPlotting(BaseModel):
     bmdu_y: float
 
     @classmethod
-    def from_model(cls, model, params) -> "ContinuousPlotting":
+    def from_model(cls, model, params) -> Self:
         summary = model.structs.summary
         xs = np.array([summary.bmdl, summary.bmd, summary.bmdu])
         dr_x = model.dataset.dose_linspace
@@ -510,7 +510,7 @@ class ContinuousPlotting(BaseModel):
             bmdu_y=critical_ys[2],
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
@@ -560,7 +560,7 @@ class ContinuousResult(BaseModel):
         )
 
     @classmethod
-    def from_model(cls, model) -> "ContinuousResult":
+    def from_model(cls, model) -> Self:
         summary = model.structs.summary
         params = ContinuousParameters.from_model(model)
         return cls(

--- a/bmds/bmds3/types/continuous.py
+++ b/bmds/bmds3/types/continuous.py
@@ -1,6 +1,6 @@
 import ctypes
 from enum import IntEnum
-from typing import Optional, Self, Union
+from typing import Optional, Self
 
 import numpy as np
 import pandas as pd
@@ -54,7 +54,7 @@ class ContinuousModelSettings(BaseModel):
     samples: int = 0
     degree: int = 0  # polynomial only
     burnin: int = 20
-    priors: Union[None, PriorClass, ModelPriors]  # if None; default used
+    priors: PriorClass | ModelPriors | None  # if None; default used
 
     @property
     def bmr_text(self) -> str:

--- a/bmds/bmds3/types/dichotomous.py
+++ b/bmds/bmds3/types/dichotomous.py
@@ -1,6 +1,6 @@
 import ctypes
 from enum import IntEnum
-from typing import Dict, List, Union
+from typing import Self, Union
 
 import numpy as np
 from pydantic import BaseModel, confloat, conint
@@ -154,7 +154,7 @@ class DichotomousModelResult(BaseModel):
     bmd_dist: NumpyFloatArray
 
     @classmethod
-    def from_model(cls, model) -> "DichotomousModelResult":
+    def from_model(cls, model) -> Self:
         result = model.structs.result
         summary = model.structs.summary
         # reshape; get rid of 0 and inf; must be JSON serializable
@@ -172,16 +172,16 @@ class DichotomousModelResult(BaseModel):
             bmd_dist=arr,
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
 
 class DichotomousPgofResult(BaseModel):
-    expected: List[float]
-    residual: List[float]
-    eb_lower: List[float]
-    eb_upper: List[float]
+    expected: list[float]
+    residual: list[float]
+    eb_lower: list[float]
+    eb_upper: list[float]
     test_statistic: float
     p_value: float
     roi: float
@@ -220,7 +220,7 @@ class DichotomousPgofResult(BaseModel):
 
 
 class DichotomousParameters(BaseModel):
-    names: List[str]
+    names: list[str]
     values: NumpyFloatArray
     se: NumpyFloatArray
     lower_ci: NumpyFloatArray
@@ -239,7 +239,7 @@ class DichotomousParameters(BaseModel):
         return np.array(priors_list, dtype=np.float64).T
 
     @classmethod
-    def from_model(cls, model) -> "DichotomousParameters":
+    def from_model(cls, model) -> Self:
         result = model.structs.result
         summary = model.structs.summary
         param_names = model.get_param_names()
@@ -259,7 +259,7 @@ class DichotomousParameters(BaseModel):
             prior_max_value=priors[4],
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
@@ -286,7 +286,7 @@ class DichotomousParameters(BaseModel):
             )
         return pretty_table(data, headers)
 
-    def rows(self, extras: Dict) -> List[Dict]:
+    def rows(self, extras: dict) -> list[dict]:
         rows = []
         for i in range(len(self.names)):
             rows.append(
@@ -311,15 +311,15 @@ class DichotomousParameters(BaseModel):
 
 
 class DichotomousAnalysisOfDeviance(BaseModel):
-    names: List[str]
-    ll: List[float]
-    params: List[int]
-    deviance: List[float]
-    df: List[int]
-    p_value: List[float]
+    names: list[str]
+    ll: list[float]
+    params: list[int]
+    deviance: list[float]
+    df: list[int]
+    p_value: list[float]
 
     @classmethod
-    def from_model(cls, model) -> "DichotomousAnalysisOfDeviance":
+    def from_model(cls, model) -> Self:
         aod = model.structs.aod
         return cls(
             names=["Full model", "Fitted model", "Reduced model"],
@@ -356,7 +356,7 @@ class DichotomousPlotting(BaseModel):
     bmdu_y: float
 
     @classmethod
-    def from_model(cls, model, params) -> "DichotomousPlotting":
+    def from_model(cls, model, params) -> Self:
         summary = model.structs.summary
         xs = np.array([summary.bmdl, summary.bmd, summary.bmdu])
         dr_x = model.dataset.dose_linspace
@@ -371,7 +371,7 @@ class DichotomousPlotting(BaseModel):
             bmdu_y=critical_ys[2],
         )
 
-    def dict(self, **kw) -> Dict:
+    def dict(self, **kw) -> dict:
         d = super().dict(**kw)
         return NumpyFloatArray.listify(d)
 
@@ -388,7 +388,7 @@ class DichotomousResult(BaseModel):
     plotting: DichotomousPlotting
 
     @classmethod
-    def from_model(cls, model) -> "DichotomousResult":
+    def from_model(cls, model) -> Self:
         summary = model.structs.summary
         fit = DichotomousModelResult.from_model(model)
         gof = DichotomousPgofResult.from_model(model)

--- a/bmds/bmds3/types/dichotomous.py
+++ b/bmds/bmds3/types/dichotomous.py
@@ -1,6 +1,6 @@
 import ctypes
 from enum import IntEnum
-from typing import Self, Union
+from typing import Self
 
 import numpy as np
 from pydantic import BaseModel, confloat, conint
@@ -39,7 +39,7 @@ class DichotomousModelSettings(BaseModel):
     degree: conint(ge=0, le=8) = 0  # multistage only
     samples: conint(ge=10, le=1000) = 100
     burnin: conint(ge=5, le=1000) = 20
-    priors: Union[None, PriorClass, ModelPriors]  # if None; default used
+    priors: PriorClass | ModelPriors | None  # if None; default used
 
     @property
     def bmr_text(self) -> str:

--- a/bmds/bmds3/types/priors.py
+++ b/bmds/bmds3/types/priors.py
@@ -1,6 +1,6 @@
 from itertools import chain
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -19,14 +19,14 @@ class Prior(BaseModel):
     min_value: float
     max_value: float
 
-    def numeric_list(self) -> List[float]:
+    def numeric_list(self) -> list[float]:
         return list(self.dict(exclude={"name"}).values())
 
 
 class ModelPriors(BaseModel):
     prior_class: PriorClass  # if this is a predefined model class
-    priors: List[Prior]  # priors for main model
-    variance_priors: Optional[List[Prior]]  # priors for variance model (continuous-only)
+    priors: list[Prior]  # priors for main model
+    variance_priors: Optional[list[Prior]]  # priors for variance model (continuous-only)
 
     def __str__(self) -> str:
         return self.tbl()
@@ -95,7 +95,7 @@ class ModelPriors(BaseModel):
 
 
 # lazy mapping; saves copy as requested
-_model_priors: Dict[str, ModelPriors] = {}
+_model_priors: dict[str, ModelPriors] = {}
 
 
 def _load_model_priors():

--- a/bmds/bmds3/types/sessions.py
+++ b/bmds/bmds3/types/sessions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ class VersionSchema(BaseModel):
 class SessionSchemaBase(BaseModel):
     version: VersionSchema
     dataset: DatasetSchemaBase
-    models: List[BmdModelSchema]
+    models: list[BmdModelSchema]
     model_average: Optional[BmdModelAveragingSchema]
     recommender: Optional[RecommenderSchema]
     selected: SelectedModelSchema

--- a/bmds/bmds3/types/structs.py
+++ b/bmds/bmds3/types/structs.py
@@ -1,6 +1,6 @@
 import ctypes
 from textwrap import dedent
-from typing import List, NamedTuple
+from typing import NamedTuple, Self
 
 import numpy as np
 import numpy.typing as npt
@@ -288,7 +288,7 @@ class DichotomousMAAnalysisStruct(ctypes.Structure):
         ("modelPriors", ctypes.POINTER(ctypes.c_double)),
     ]
 
-    def __init__(self, models: List[DichotomousAnalysisStruct], model_weights: npt.NDArray):
+    def __init__(self, models: list[DichotomousAnalysisStruct], model_weights: npt.NDArray):
         self.np_nparms = np.array([model.parms for model in models], dtype=np.int32)
         self.np_actual_parms = self.np_nparms.copy()
         self.np_prior_cols = np.array([model.prior_cols for model in models], dtype=np.int32)
@@ -340,7 +340,7 @@ class DichotomousMAResultStruct(ctypes.Structure):
         ("bmd_dist", ctypes.POINTER(ctypes.c_double)),
     ]
 
-    def __init__(self, models: List[DichotomousModelResultStruct]):
+    def __init__(self, models: list[DichotomousModelResultStruct]):
         self.nmodels = len(models)
         self.models = list_t_c(
             [ctypes.pointer(model) for model in models],
@@ -411,7 +411,7 @@ class DichotomousMAStructs(NamedTuple):
     result: MAResultsStruct
 
     @classmethod
-    def from_session(cls, dataset, models, weights) -> "DichotomousMAStructs":
+    def from_session(cls, dataset, models, weights) -> Self:
 
         return cls(
             analysis=DichotomousMAAnalysisStruct(

--- a/bmds/constants.py
+++ b/bmds/constants.py
@@ -1,4 +1,4 @@
-import enum
+from enum import IntEnum, StrEnum
 
 DICHOTOMOUS = "D"
 DICHOTOMOUS_CANCER = "DC"
@@ -8,7 +8,7 @@ NESTED_DICHOTOMOUS = "ND"
 MULTI_TUMOR = "MT"
 
 
-class ModelClass(str, enum.Enum):
+class ModelClass(StrEnum):
     # Types of modeling sessions
     DICHOTOMOUS = DICHOTOMOUS
     CONTINUOUS = CONTINUOUS
@@ -16,7 +16,7 @@ class ModelClass(str, enum.Enum):
     MULTI_TUMOR = MULTI_TUMOR
 
 
-class Dtype(str, enum.Enum):
+class Dtype(StrEnum):
     # Types of dose-response datasets
     DICHOTOMOUS = DICHOTOMOUS
     DICHOTOMOUS_CANCER = DICHOTOMOUS_CANCER
@@ -42,7 +42,7 @@ BMDS_TWOS = {BMDS270}
 BMDS_THREES = {BMDS330}
 
 
-class Version(str, enum.Enum):
+class Version(StrEnum):
     BMDS270 = "BMDS270"
     BMDS330 = "BMDS330"
 
@@ -181,7 +181,7 @@ BOOL_ICON = {True: "yes", False: "no"}  # unicode issues with Consolas font
 BIN_TEXT_BMDS3 = {BIN_NO_CHANGE: "Viable", BIN_WARNING: "Questionable", BIN_FAILURE: "Unusable"}
 
 
-class LogicBin(enum.IntEnum):
+class LogicBin(IntEnum):
     NO_CHANGE = BIN_NO_CHANGE
     WARNING = BIN_WARNING
     FAILURE = BIN_FAILURE

--- a/bmds/datasets/base.py
+++ b/bmds/datasets/base.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, List, Optional, TypeVar
+from typing import Optional, TypeVar
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -145,7 +145,7 @@ class DatasetSchemaBase(BaseModel, abc.ABC):
         from .dichotomous import DichotomousCancerDatasetSchema, DichotomousDatasetSchema
         from .nested_dichotomous import NestedDichotomousDatasetSchema
 
-        _dataset_schema_map: Dict = {
+        _dataset_schema_map: dict = {
             Dtype.CONTINUOUS: ContinuousDatasetSchema,
             Dtype.CONTINUOUS_INDIVIDUAL: ContinuousIndividualDatasetSchema,
             Dtype.DICHOTOMOUS: DichotomousDatasetSchema,
@@ -163,6 +163,6 @@ class DatasetSchemaBase(BaseModel, abc.ABC):
 
 
 class DatasetPlottingSchema(BaseModel):
-    mean: Optional[List[float]]
-    ll: List[float]
-    ul: List[float]
+    mean: Optional[list[float]]
+    ll: list[float]
+    ul: list[float]

--- a/bmds/datasets/continuous.py
+++ b/bmds/datasets/continuous.py
@@ -1,5 +1,5 @@
 import math
-from typing import ClassVar, Optional, Union
+from typing import ClassVar, Optional
 
 import numpy as np
 import pandas as pd
@@ -452,5 +452,5 @@ class ContinuousIndividualDatasetSchema(DatasetSchemaBase):
         return ds
 
 
-ContinuousDatasets = Union[ContinuousDataset, ContinuousIndividualDataset]
-ContinuousDatasetSchemas = Union[ContinuousDatasetSchema, ContinuousIndividualDatasetSchema]
+ContinuousDatasets = ContinuousDataset | ContinuousIndividualDataset
+ContinuousDatasetSchemas = ContinuousDatasetSchema | ContinuousIndividualDatasetSchema

--- a/bmds/datasets/continuous.py
+++ b/bmds/datasets/continuous.py
@@ -1,5 +1,5 @@
 import math
-from typing import ClassVar, List, Optional, Union
+from typing import ClassVar, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -90,10 +90,10 @@ class ContinuousDataset(ContinuousSummaryDataMixin, DatasetBase):
 
     def __init__(
         self,
-        doses: List[float],
-        ns: List[float],
-        means: List[float],
-        stdevs: List[float],
+        doses: list[float],
+        ns: list[float],
+        means: list[float],
+        stdevs: list[float],
         **metadata,
     ):
         self.doses = doses
@@ -216,10 +216,10 @@ class ContinuousDataset(ContinuousSummaryDataMixin, DatasetBase):
 class ContinuousDatasetSchema(DatasetSchemaBase):
     dtype: constants.Dtype
     metadata: DatasetMetadata
-    doses: List[confloat(ge=0)]
-    ns: List[confloat(gt=0)]
-    means: List[float]
-    stdevs: List[confloat(ge=0)]
+    doses: list[confloat(ge=0)]
+    ns: list[confloat(gt=0)]
+    means: list[float]
+    stdevs: list[confloat(ge=0)]
     anova: Optional[AnovaTests]
     plotting: Optional[DatasetPlottingSchema]
 
@@ -288,7 +288,7 @@ class ContinuousIndividualDataset(ContinuousSummaryDataMixin, DatasetBase):
     MINIMUM_DOSE_GROUPS = 3
     dtype = constants.Dtype.CONTINUOUS_INDIVIDUAL
 
-    def __init__(self, doses: List[float], responses: List[float], **metadata):
+    def __init__(self, doses: list[float], responses: list[float], **metadata):
         data = self._prepare_summary_data(doses, responses)
         for key, value in data.items():
             setattr(self, key, value)
@@ -421,8 +421,8 @@ class ContinuousIndividualDataset(ContinuousSummaryDataMixin, DatasetBase):
 class ContinuousIndividualDatasetSchema(DatasetSchemaBase):
     dtype: constants.Dtype
     metadata: DatasetMetadata
-    doses: List[confloat(ge=0)]
-    responses: List[float]
+    doses: list[confloat(ge=0)]
+    responses: list[float]
     anova: Optional[AnovaTests]
 
     MIN_N: ClassVar = 3

--- a/bmds/datasets/dichotomous.py
+++ b/bmds/datasets/dichotomous.py
@@ -1,5 +1,5 @@
 import math
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Optional
 
 import numpy as np
 from matplotlib.figure import Figure
@@ -34,7 +34,7 @@ class DichotomousDataset(DatasetBase):
 
     DEFAULT_YLABEL = "Fraction affected"
 
-    def __init__(self, doses: List[float], ns: List[float], incidences: List[float], **metadata):
+    def __init__(self, doses: list[float], ns: list[float], incidences: list[float], **metadata):
         self.doses = doses
         self.ns = ns
         self.incidences = incidences
@@ -193,9 +193,9 @@ class DichotomousDataset(DatasetBase):
 class DichotomousDatasetSchema(DatasetSchemaBase):
     dtype: constants.Dtype
     metadata: DatasetMetadata
-    doses: List[confloat(ge=0)]
-    ns: List[confloat(gt=0)]
-    incidences: List[confloat(ge=0)]
+    doses: list[confloat(ge=0)]
+    ns: list[confloat(gt=0)]
+    incidences: list[confloat(ge=0)]
     plotting: Optional[DatasetPlottingSchema]
 
     MIN_N: ClassVar = 3

--- a/bmds/datasets/nested_dichotomous.py
+++ b/bmds/datasets/nested_dichotomous.py
@@ -1,5 +1,5 @@
 import math
-from typing import ClassVar, List
+from typing import ClassVar
 
 import numpy as np
 from pydantic import root_validator
@@ -18,10 +18,10 @@ class NestedDichotomousDataset(DatasetBase):
 
     def __init__(
         self,
-        doses: List[float],
-        litter_ns: List[int],
-        incidences: List[float],
-        litter_covariates: List[int],
+        doses: list[float],
+        litter_ns: list[int],
+        incidences: list[float],
+        litter_covariates: list[int],
         **metadata,
     ):
         self.doses = doses
@@ -119,10 +119,10 @@ class NestedDichotomousDataset(DatasetBase):
 class NestedDichotomousDatasetSchema(DatasetSchemaBase):
     dtype: constants.Dtype = constants.Dtype.NESTED_DICHOTOMOUS
     metadata: DatasetMetadata
-    doses: List[float]
-    litter_ns: List[int]
-    incidences: List[int]
-    litter_covariates: List[float]
+    doses: list[float]
+    litter_ns: list[int]
+    incidences: list[int]
+    litter_covariates: list[float]
 
     MIN_N: ClassVar = 3
     MAX_N: ClassVar = math.inf

--- a/bmds/reporting/styling.py
+++ b/bmds/reporting/styling.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 from docx import Document
 from docx.shared import Inches
@@ -32,7 +32,7 @@ class Report(BaseModel):
     styles: ReporterStyleGuide
 
     @classmethod
-    def build_default(cls) -> "Report":
+    def build_default(cls) -> Self:
         fn = Path(__file__).parent / "templates/base.docx"
         doc = Document(str(fn))
         return Report(document=doc, styles=ReporterStyleGuide())

--- a/bmds/session.py
+++ b/bmds/session.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from . import constants
 from .bmds2.sessions import BMDS_v270
@@ -10,7 +10,7 @@ class BMDS:
     A single dataset, related models, outputs, and model recommendations.
     """
 
-    _BMDS_VERSIONS: Dict[str, Any] = {
+    _BMDS_VERSIONS: dict[str, Any] = {
         constants.BMDS270: BMDS_v270,
         constants.BMDS330: Bmds330,
     }

--- a/bmds/stats/anova.py
+++ b/bmds/stats/anova.py
@@ -50,44 +50,44 @@ class AnovaTests(BaseModel):
         # The xlk is not real
         xlk = (a1 + a2 + a3 + ar) / 4
         parm_known = 1
-        anovalist = [Test() for i in range(5)]
+        anovas = [Test() for i in range(5)]
 
         # Compute DF and assign LLK for each test
-        anovalist[0].DF = n_obs + 1
-        anovalist[0].SS = a1
+        anovas[0].DF = n_obs + 1
+        anovas[0].SS = a1
 
-        anovalist[1].DF = 2 * n_obs
-        anovalist[1].SS = a2
+        anovas[1].DF = 2 * n_obs
+        anovas[1].SS = a2
 
-        anovalist[2].DF = n_obs + 2 - parm_known
-        anovalist[2].SS = a3
+        anovas[2].DF = n_obs + 2 - parm_known
+        anovas[2].SS = a3
 
-        anovalist[3].DF = 2
-        anovalist[3].SS = ar
+        anovas[3].DF = 2
+        anovas[3].SS = ar
 
-        anovalist[4].DF = nparm - 2
-        anovalist[4].SS = xlk
+        anovas[4].DF = nparm - 2
+        anovas[4].SS = xlk
 
         # Compute likelihood ratio MSE and CDF
-        anovalist[0].MSE = 2 * (a2 - a1)
-        anovalist[0].CDF = anovalist[1].DF - anovalist[0].DF
+        anovas[0].MSE = 2 * (a2 - a1)
+        anovas[0].CDF = anovas[1].DF - anovas[0].DF
 
-        anovalist[1].MSE = 2 * (a2 - a3)
-        anovalist[1].CDF = anovalist[1].DF - anovalist[2].DF
+        anovas[1].MSE = 2 * (a2 - a3)
+        anovas[1].CDF = anovas[1].DF - anovas[2].DF
 
-        anovalist[2].MSE = 2 * (a3 - xlk)
-        anovalist[2].CDF = anovalist[2].DF - anovalist[4].DF
+        anovas[2].MSE = 2 * (a3 - xlk)
+        anovas[2].CDF = anovas[2].DF - anovas[4].DF
 
-        anovalist[3].MSE = 2 * (a2 - ar)
-        anovalist[3].CDF = anovalist[1].DF - anovalist[3].DF
+        anovas[3].MSE = 2 * (a2 - ar)
+        anovas[3].CDF = anovas[1].DF - anovas[3].DF
 
-        for anova in anovalist:
+        for anova in anovas:
             anova.AIC = -2 * (anova.SS - anova.DF)
             if anova.MSE >= 0.0 and anova.CDF > 0:
                 anova.TEST = 1 - stats.chi2.cdf(anova.MSE, anova.CDF)
 
         # Only return test 1, test 2 and test 3 in the order
-        return cls(test1=anovalist[3], test2=anovalist[0], test3=anovalist[1])
+        return cls(test1=anovas[3], test2=anovas[0], test3=anovas[1])
 
     @staticmethod
     def output_3tests(tests) -> str:

--- a/bmds/stats/anova.py
+++ b/bmds/stats/anova.py
@@ -1,4 +1,5 @@
 from math import log
+from typing import Self
 
 from pydantic import BaseModel
 from scipy import stats
@@ -43,50 +44,50 @@ class AnovaTests(BaseModel):
         return lkA1, lkA2, lkA3, lkR
 
     @classmethod
-    def get_anova_c3_tests(cls, nparm, n_obs, a1, a2, a3, ar) -> "AnovaTests":
+    def get_anova_c3_tests(cls, nparm, n_obs, a1, a2, a3, ar) -> Self:
         # Based on Hill model, modified from DTMS3ANOVAC.c
 
         # The xlk is not real
         xlk = (a1 + a2 + a3 + ar) / 4
         parm_known = 1
-        anovaList = [Test() for i in range(5)]
+        anovalist = [Test() for i in range(5)]
 
         # Compute DF and assign LLK for each test
-        anovaList[0].DF = n_obs + 1
-        anovaList[0].SS = a1
+        anovalist[0].DF = n_obs + 1
+        anovalist[0].SS = a1
 
-        anovaList[1].DF = 2 * n_obs
-        anovaList[1].SS = a2
+        anovalist[1].DF = 2 * n_obs
+        anovalist[1].SS = a2
 
-        anovaList[2].DF = n_obs + 2 - parm_known
-        anovaList[2].SS = a3
+        anovalist[2].DF = n_obs + 2 - parm_known
+        anovalist[2].SS = a3
 
-        anovaList[3].DF = 2
-        anovaList[3].SS = ar
+        anovalist[3].DF = 2
+        anovalist[3].SS = ar
 
-        anovaList[4].DF = nparm - 2
-        anovaList[4].SS = xlk
+        anovalist[4].DF = nparm - 2
+        anovalist[4].SS = xlk
 
         # Compute likelihood ratio MSE and CDF
-        anovaList[0].MSE = 2 * (a2 - a1)
-        anovaList[0].CDF = anovaList[1].DF - anovaList[0].DF
+        anovalist[0].MSE = 2 * (a2 - a1)
+        anovalist[0].CDF = anovalist[1].DF - anovalist[0].DF
 
-        anovaList[1].MSE = 2 * (a2 - a3)
-        anovaList[1].CDF = anovaList[1].DF - anovaList[2].DF
+        anovalist[1].MSE = 2 * (a2 - a3)
+        anovalist[1].CDF = anovalist[1].DF - anovalist[2].DF
 
-        anovaList[2].MSE = 2 * (a3 - xlk)
-        anovaList[2].CDF = anovaList[2].DF - anovaList[4].DF
+        anovalist[2].MSE = 2 * (a3 - xlk)
+        anovalist[2].CDF = anovalist[2].DF - anovalist[4].DF
 
-        anovaList[3].MSE = 2 * (a2 - ar)
-        anovaList[3].CDF = anovaList[1].DF - anovaList[3].DF
+        anovalist[3].MSE = 2 * (a2 - ar)
+        anovalist[3].CDF = anovalist[1].DF - anovalist[3].DF
 
-        for anova in anovaList:
+        for anova in anovalist:
             anova.AIC = -2 * (anova.SS - anova.DF)
             if anova.MSE >= 0.0 and anova.CDF > 0:
                 anova.TEST = 1 - stats.chi2.cdf(anova.MSE, anova.CDF)
 
         # Only return test 1, test 2 and test 3 in the order
-        return cls(test1=anovaList[3], test2=anovaList[0], test3=anovaList[1])
+        return cls(test1=anovalist[3], test2=anovalist[0], test3=anovalist[1])
 
     @staticmethod
     def output_3tests(tests) -> str:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,7 +5,7 @@
 [![docs](https://readthedocs.org/projects/bmds/badge/?version=latest)](https://bmds.readthedocs.io/en/latest/?badge=latest)
 [![zenodo](https://zenodo.org/badge/61229626.svg)](https://zenodo.org/badge/latestdoi/61229626)
 
-A python package is designed to run the [USEPA BMDS](https://www.epa.gov/bmds) software. It requires Python3.9+.
+A python package is designed to run the [USEPA BMDS](https://www.epa.gov/bmds) software. It requires Python3.11+.
 
 ## Quickstart
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,6 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 
@@ -19,6 +17,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
+requires-python = ">=3.11"
 install_requires =
     matplotlib
     numpy


### PR DESCRIPTION
Add `require-python` >= 3.11 to the package, since we're using some type annotation features. Prior versions only required 3.9; with this PR the latest python version is now required.

- update typing to use built-in dict, list, set, tuple (python 3.9)
- Use | for Union (python 3.10)
- use Self for returning a class instance (python 3.11)
- use StrEnum (python 3.11)