### PR TITLE
API improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ venv/
 
 # created by bmds2.7
 log.txt
+
+# should only available in next brach
+bmdscore*

--- a/bmds/bmds3/constants.py
+++ b/bmds/bmds3/constants.py
@@ -142,8 +142,8 @@ class ContinuousModelChoices(Enum):
 
 
 class DistType(IntEnum):
-    normal = 1
-    normal_ncv = 2
+    normal = 1  # f(i) = a * x(i)
+    normal_ncv = 2  # f(i) = a * x(i) ^ p
     log_normal = 3
 
     @property

--- a/bmds/bmds3/models/continuous.py
+++ b/bmds/bmds3/models/continuous.py
@@ -31,9 +31,13 @@ class BmdModelContinuous(BmdModel):
         else:
             model_settings = ContinuousModelSettings.parse_obj(settings)
 
-        # only estimate direction if unspecified in settings
+        # only estimate direction if unspecified
         if model_settings.is_increasing is None:
             model_settings.is_increasing = dataset.is_increasing
+
+        # set preferred variance model if unspecified
+        if settings is None or isinstance(settings, dict) and "disttype" not in settings:
+            model_settings.disttype = self.set_constant_variance_value()
 
         # get default values, may require further model customization
         if not isinstance(model_settings.priors, ModelPriors):
@@ -47,6 +51,13 @@ class BmdModelContinuous(BmdModel):
             )
 
         return model_settings
+
+    def set_constant_variance_value(self) -> DistType:
+        # set modeled variance if p-test 2 < 0.05 or not calculated, otherwise constant
+        anova = self.dataset.anova()
+        return (
+            DistType.normal_ncv if (anova is None or anova.test2.TEST < 0.05) else DistType.normal
+        )
 
     def _build_inputs(self) -> ContinuousAnalysis:
         return ContinuousAnalysis(

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -95,13 +95,11 @@ class RecommenderResults(BaseModel):
 
     def update_record(self, d: dict, index: int) -> None:
         """Update data record for a tabular-friendly export"""
-        notes = self.model_notes[index]
         d.update(
             recommended=(index == self.recommended_model_index),
             recommendation_bin=self.bin_text(index),
-            recommendation_notes="\n".join(itertools.chain(notes[0], notes[1], notes[2])),
+            recommendation_notes=self.notes_text(index),
         )
-        # TODO - refactor this; notes text is useful
 
 
 class RecommenderSchema(BaseModel):

--- a/bmds/bmds3/recommender/recommender.py
+++ b/bmds/bmds3/recommender/recommender.py
@@ -101,6 +101,7 @@ class RecommenderResults(BaseModel):
             recommendation_bin=self.bin_text(index),
             recommendation_notes="\n".join(itertools.chain(notes[0], notes[1], notes[2])),
         )
+        # TODO - refactor this; notes text is useful
 
 
 class RecommenderSchema(BaseModel):

--- a/bmds/bmds3/types/priors.py
+++ b/bmds/bmds3/types/priors.py
@@ -52,6 +52,17 @@ class ModelPriors(BaseModel):
                 return p
         raise ValueError(f"No parameter named {name}")
 
+    def update(self, name: str, **kw):
+        """Update a prior inplace.
+
+        Args:
+            name (str): the prior name
+            **kw: fields to update
+        """
+        prior = self.get_prior(name)
+        for k, v in kw.items():
+            setattr(prior, k, v)
+
     def priors_list(
         self, degree: int | None = None, dist_type: DistType | None = None
     ) -> list[list]:

--- a/tests/bmds3/models/test_continuous.py
+++ b/tests/bmds3/models/test_continuous.py
@@ -13,14 +13,14 @@ class TestPriorOverrides:
     def test_poly(self, cdataset2, negative_cdataset):
         for settings, priors in [
             # fmt: off
-            ({"is_increasing": True}, (0, 1e6)),
-            ({"is_increasing": False}, (-1e6, 0)),
-            ({"is_increasing": True, "disttype": DistType.normal_ncv}, (0, 18)),
-            ({"is_increasing": False, "disttype": DistType.normal_ncv}, (-18, 0)),
-            ({"priors": PriorClass.frequentist_unrestricted, "is_increasing": True}, (-1e6, 1e6)),
-            ({"priors": PriorClass.frequentist_unrestricted, "is_increasing": False}, (-1e6, 1e6)),
-            ({"priors": PriorClass.frequentist_unrestricted, "is_increasing": True, "disttype": DistType.normal_ncv}, (-18, 18)),
-            ({"priors": PriorClass.frequentist_unrestricted, "is_increasing": False, "disttype": DistType.normal_ncv}, (-18, 18)),
+            ({"disttype": DistType.normal, "is_increasing": True}, (0, 1e6)),
+            ({"disttype": DistType.normal, "is_increasing": False}, (-1e6, 0)),
+            ({"disttype": DistType.normal_ncv, "is_increasing": True}, (0, 18)),
+            ({"disttype": DistType.normal_ncv, "is_increasing": False}, (-18, 0)),
+            ({"disttype": DistType.normal, "priors": PriorClass.frequentist_unrestricted, "is_increasing": True}, (-1e6, 1e6)),
+            ({"disttype": DistType.normal, "priors": PriorClass.frequentist_unrestricted, "is_increasing": False}, (-1e6, 1e6)),
+            ({"disttype": DistType.normal_ncv, "priors": PriorClass.frequentist_unrestricted, "is_increasing": True}, (-18, 18)),
+            ({"disttype": DistType.normal_ncv, "priors": PriorClass.frequentist_unrestricted, "is_increasing": False}, (-18, 18)),
             # fmt: on
         ]:
             model = continuous.Polynomial(cdataset2, settings)
@@ -48,7 +48,7 @@ class TestPriorOverrides:
 
     def test_power(self, cdataset2):
         for settings, priors in [
-            ({}, [0.1, -100, 100]),
+            ({"disttype": DistType.normal}, [0.1, -100, 100]),
             ({"disttype": DistType.normal_ncv}, [1, -10000, 10000]),
         ]:
             model = continuous.Power(cdataset2, settings)
@@ -61,7 +61,6 @@ class TestBmdModelContinuous:
     def test_get_param_names(self, cdataset2):
         # test normal model case
         for m in [
-            continuous.Power(dataset=cdataset2),
             continuous.Power(dataset=cdataset2, settings=dict(disttype=DistType.normal)),
             continuous.Power(dataset=cdataset2, settings=dict(disttype=DistType.log_normal)),
         ]:
@@ -70,11 +69,13 @@ class TestBmdModelContinuous:
         assert m.get_param_names() == ["g", "v", "n", "rho", "alpha"]
 
         # test polynomial
-        model = continuous.Linear(dataset=cdataset2)
+        model = continuous.Linear(dataset=cdataset2, settings=dict(disttype=DistType.normal))
         assert model.get_param_names() == ["g", "b1", "alpha"]
-        model = continuous.Polynomial(dataset=cdataset2)
+        model = continuous.Polynomial(dataset=cdataset2, settings=dict(disttype=DistType.normal))
         assert model.get_param_names() == ["g", "b1", "b2", "alpha"]
-        model = continuous.Polynomial(dataset=cdataset2, settings=dict(degree=3))
+        model = continuous.Polynomial(
+            dataset=cdataset2, settings=dict(degree=3, disttype=DistType.normal)
+        )
         assert model.get_param_names() == ["g", "b1", "b2", "b3", "alpha"]
         model = continuous.Polynomial(
             dataset=cdataset2, settings=dict(degree=3, disttype=DistType.normal_ncv)
@@ -109,6 +110,25 @@ class TestBmdModelContinuous:
         model.execute()
         return model.plot()
 
+    def test_automated_disttype_selection(self, cdataset, cidataset):
+        # check that automated selection is correct for < 0.05
+        model = continuous.Power(cdataset, settings=None)
+        assert model.settings.disttype == DistType.normal_ncv
+        assert model.dataset.anova().dict()["test2"]["TEST"] < 0.05
+
+        # but we can override if we want
+        model = continuous.Power(cdataset, settings=dict(disttype=DistType.normal))
+        assert model.settings.disttype == DistType.normal
+
+        # check that automated selection is correct for > 0.05
+        model = continuous.Power(cidataset, settings=None)
+        assert model.dataset.anova().dict()["test2"]["TEST"] > 0.05
+        assert model.settings.disttype == DistType.normal
+
+        # but we can override if we want
+        model = continuous.Power(cdataset, settings=dict(disttype=DistType.normal_ncv))
+        assert model.settings.disttype == DistType.normal_ncv
+
 
 def test_increasing(cdataset2):
     """
@@ -123,7 +143,7 @@ def test_increasing(cdataset2):
         (continuous.Linear, [26, 24, 28], 3068),
         (continuous.Polynomial, [26, 24, 29], 3070),
     ]:
-        result = Model(cdataset2).execute()
+        result = Model(cdataset2, settings=dict(disttype=DistType.normal)).execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
         # res = f"(continuous.{Model.__name__}, {np.round(actual, 0).astype(int).tolist()}, {round(result.fit.aic)}),"
@@ -142,7 +162,7 @@ def test_decreasing(negative_cdataset):
         (continuous.Linear, [35, 33, 38], 3117),
         (continuous.Polynomial, [52, 47, 60], 3077),
     ]:
-        model = Model(negative_cdataset)
+        model = Model(negative_cdataset, settings=dict(disttype=DistType.normal))
         result = model.execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         # for regenerating values
@@ -159,7 +179,7 @@ def test_bmds3_continuous_float_counts(cdataset2):
     for Model, bmd_values, aic in [
         (continuous.Power, [25.9, 24.3, 29.8], 3067),
     ]:
-        model = Model(cdataset2)
+        model = Model(cdataset2, settings=dict(disttype=DistType.normal))
         result = model.execute()
         actual = [result.bmd, result.bmdl, result.bmdu]
         assert pytest.approx(bmd_values, rel=0.05) == actual

--- a/tests/bmds3/types/test_continuous.py
+++ b/tests/bmds3/types/test_continuous.py
@@ -28,7 +28,7 @@ class TestContinuousParameters:
         returned output effectively drops the c array and shifts all other values down one.
         We check that the input and output values are shifted as required.
         """
-        model = continuous.ExponentialM3(cdataset)
+        model = continuous.ExponentialM3(cdataset, settings=dict(disttype=DistType.normal))
         res = model.execute()
         # param names for prior are as expected
         assert model.get_param_names() == ["a", "b", "c", "d", "log-alpha"]

--- a/tests/bmds3/types/test_prior.py
+++ b/tests/bmds3/types/test_prior.py
@@ -23,6 +23,18 @@ def mock_prior():
 
 
 class TestModelPriors:
+    def test_get_prior(self, mock_prior):
+        assert mock_prior.get_prior("a").name == "a"
+        assert mock_prior.get_prior("d").name == "d"
+        with pytest.raises(ValueError):
+            mock_prior.get_prior("z")
+
+    def test_update(self, mock_prior):
+        a = mock_prior.get_prior("a")
+        assert a.initial_value == 1
+        mock_prior.update("a", initial_value=2)
+        assert a.initial_value == 2
+
     def test_to_c(self, mock_prior):
         # fmt: off
         assert np.allclose(


### PR DESCRIPTION
1. Add an `update` method to priors:

```python
model = Power(dataset)
model.settings.priors.update('g', max_value=12345)
print(model.settings.priors.tbl())
```

2. Provide a better variance model selection for continuous modeling. It pre-runs ptest 2 and picks constant or nonconstant variable if no default is specified. 