### PR TITLE
fix model average results not updating

### DIFF
--- a/bmds/bmds3/types/ma.py
+++ b/bmds/bmds3/types/ma.py
@@ -56,6 +56,8 @@ class DichotomousModelAverage:
 
     def execute(self) -> "DichotomousModelAverageResult":
         bmdscore.pythonBMDSDichoMA(self.average, self.result)
+        # bmdsRes is copied in bmdscore.pythonBMDSDichoMA; replace python pointer with copy
+        self.bmdsRes = self.result.bmdsRes
 
     def __str__(self) -> str:
         lines = []

--- a/bmds/bmds3/types/ma.py
+++ b/bmds/bmds3/types/ma.py
@@ -52,12 +52,10 @@ class DichotomousModelAverage:
         self.analysis = analysis
         self.average = average
         self.result = result
-        self.bmdsRes = bmdsRes
+        self.bmdsRes = result.bmdsRes  # use this version; copied on assignment above
 
     def execute(self) -> "DichotomousModelAverageResult":
         bmdscore.pythonBMDSDichoMA(self.average, self.result)
-        # bmdsRes is copied in bmdscore.pythonBMDSDichoMA; replace python pointer with copy
-        self.bmdsRes = self.result.bmdsRes
 
     def __str__(self) -> str:
         lines = []

--- a/tests/bmds3/models/test_ma.py
+++ b/tests/bmds3/models/test_ma.py
@@ -16,6 +16,10 @@ class TestDichotomousMa:
         d = session.to_dict()
         assert isinstance(json.dumps(d), str)
 
+        # check bmd values exist and are valid
+        res = session.model_average.results
+        assert np.allclose([0, 0, 0], [res.bmdl, res.bmd, res.bmdu])  # TODO - fix w/ patch?
+
     def test_prior_weights(self, ddataset2):
         # default; equal weights
         session = bmds.session.Bmds330(dataset=ddataset2)

--- a/tests/bmds3/models/test_ma.py
+++ b/tests/bmds3/models/test_ma.py
@@ -18,7 +18,7 @@ class TestDichotomousMa:
 
         # check bmd values exist and are valid
         res = session.model_average.results
-        assert np.allclose([0, 0, 0], [res.bmdl, res.bmd, res.bmdu])  # TODO - fix w/ patch?
+        assert np.allclose([57.1, 65.9, 75.0], [res.bmdl, res.bmd, res.bmdu], atol=5)
 
     def test_prior_weights(self, ddataset2):
         # default; equal weights


### PR DESCRIPTION
With `bmdscore` rewrite, the instance of `bmdscore.BMDSMA_results` attached to `bmdscore.python_dichotomousMA_result` is copied when executed in `bmdscore.pythonBMDSDichoMA`, and the original instance in python doesn't have updated results.  This PR updates the python pointer after execution