### PR TITLE
replace black w/ wuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ docs-serve: ## Generate documentation
 	cd docs; mkdocs serve -a localhost:8050
 
 lint: ## Check formatting issues
-	@black . --check && ruff .
+	@ruff format . --check && ruff .
 
 format: ## Fix formatting issues where possible
-	@black . && ruff . --fix --show-fixes
+	@ruff format . && ruff . --fix --show-fixes
 
 test: ## Run all tests, except matplotlib figures
 	py.test

--- a/bmds/bmds2/logic/rules.py
+++ b/bmds/bmds2/logic/rules.py
@@ -265,9 +265,7 @@ class CorrectVarianceModel(Rule):
         if self._is_valid_number(p_value2):
             if constant_variance == 1 and p_value2 < 0.1:
                 msg = (
-                    "Incorrect variance model (p-value 2 = {}), constant variance selected".format(
-                        p_value2
-                    )
+                    f"Incorrect variance model (p-value 2 = {p_value2}), constant variance selected"
                 )
             elif constant_variance == 0 and p_value2 > 0.1:
                 msg = "Incorrect variance model (p-value 2 = {}), modeled variance selected".format(

--- a/bmds/bmds2/models/base.py
+++ b/bmds/bmds2/models/base.py
@@ -5,6 +5,7 @@ import subprocess
 from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
 from simple_settings import settings
@@ -106,7 +107,7 @@ class BMDModel(abc.ABC):
 
         try:
             proc = subprocess.run(
-                [exe, dfile],
+                [exe, dfile],  # noqa: S603
                 capture_output=True,
                 timeout=settings.BMDS_MODEL_TIMEOUT_SECONDS,
             )
@@ -344,9 +345,7 @@ class BMDModel(abc.ABC):
             return val
 
     def _dfile_print_header_rows(self):
-        return "{}\nBMDS_Model_Run\n/temp/bmd/datafile.dax\n/temp/bmd/output.out".format(
-            self.model_name
-        )
+        return f"{self.model_name}\nBMDS_Model_Run\n/temp/bmd/datafile.dax\n/temp/bmd/output.out"
 
     def _dfile_print_parameters(self, *params):
         # Print parameters in the specified order. Expects a tuple of parameter
@@ -488,55 +487,55 @@ class DefaultParams:
      - n = name (optional)
     """
 
-    bmdl_curve_calculation = {
+    bmdl_curve_calculation: ClassVar = {
         "c": constants.FC_OTHER,
         "t": constants.FT_BOOL,
         "d": 0,
         "n": "BMDL curve calculation",
     }
-    append_or_overwrite = {"c": constants.FC_OTHER, "t": constants.FT_BOOL, "d": 0}
-    smooth_option = {"c": constants.FC_OTHER, "t": constants.FT_BOOL, "d": 0}
-    bmd_calculation = {
+    append_or_overwrite: ClassVar = {"c": constants.FC_OTHER, "t": constants.FT_BOOL, "d": 0}
+    smooth_option: ClassVar = {"c": constants.FC_OTHER, "t": constants.FT_BOOL, "d": 0}
+    bmd_calculation: ClassVar = {
         "c": constants.FC_OTHER,
         "t": constants.FT_BOOL,
         "d": 1,
         "n": "BMD calculation",
     }
-    dose_drop = {
+    dose_drop: ClassVar = {
         "c": constants.FC_OTHER,
         "t": constants.FT_DROPDOSE,
         "d": 0,
         "n": "Doses to drop",
     }
-    constant_variance = {
+    constant_variance: ClassVar = {
         "c": constants.FC_OTHER,
         "t": constants.FT_BOOL,
         "d": 1,
         "n": "Constant variance",
     }
-    max_iterations = {
+    max_iterations: ClassVar = {
         "c": constants.FC_OPTIMIZER,
         "t": constants.FT_INTEGER,
         "d": 500,
         "n": "Iteration",
     }
-    relative_fn_conv = {
+    relative_fn_conv: ClassVar = {
         "c": constants.FC_OPTIMIZER,
         "t": constants.FT_DECIMAL,
         "d": 1.0e-08,
         "n": "Relative function",
     }
-    parameter_conv = {
+    parameter_conv: ClassVar = {
         "c": constants.FC_OPTIMIZER,
         "t": constants.FT_DECIMAL,
         "d": 1.0e-08,
         "n": "Parameter",
     }
-    confidence_level = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 0.95}
-    dich_bmr = {"c": constants.FC_BMR, "t": constants.FT_INTEGER, "d": 0.1}
-    dich_bmr_type = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 0}
-    cont_bmr = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 1.0}
-    cont_bmr_type = {"c": constants.FC_BMR, "t": constants.FT_INTEGER, "d": 1}
+    confidence_level: ClassVar = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 0.95}
+    dich_bmr: ClassVar = {"c": constants.FC_BMR, "t": constants.FT_INTEGER, "d": 0.1}
+    dich_bmr_type: ClassVar = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 0}
+    cont_bmr: ClassVar = {"c": constants.FC_BMR, "t": constants.FT_DECIMAL, "d": 1.0}
+    cont_bmr_type: ClassVar = {"c": constants.FC_BMR, "t": constants.FT_INTEGER, "d": 1}
 
     @staticmethod
     def degree_poly(d=2, showName=True):

--- a/bmds/bmds2/models/continuous.py
+++ b/bmds/bmds2/models/continuous.py
@@ -1,4 +1,5 @@
 import os
+from typing import ClassVar
 
 import numpy as np
 
@@ -37,7 +38,7 @@ class Polynomial_221(Continuous):
     date = "03/14/2017"
     exe = "poly"
     exe_plot = "00poly"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -125,7 +126,7 @@ class Linear_221(Polynomial_221):
     exe_plot = "00poly"
     version = 2.21
     date = "03/14/2017"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -239,7 +240,7 @@ class Exponential_M2_111(Exponential):
     exe = "exponential"
     exe_plot = "Expo_CPlot"
     exp_run_settings = "{} {} {} 1000 11 0 1"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -325,7 +326,7 @@ class Power_219(Continuous):
     model_name = constants.M_Power
     exe = "power"
     exe_plot = "00power"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -388,7 +389,7 @@ class Hill_218(Continuous):
     model_name = constants.M_Hill
     exe = "hill"
     exe_plot = "00Hill"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,

--- a/bmds/bmds2/models/dichotomous.py
+++ b/bmds/bmds2/models/dichotomous.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import ClassVar
 
 import numpy as np
 from scipy.stats import gamma, norm
@@ -33,7 +34,7 @@ class Multistage_34(Dichotomous):
     model_name = constants.M_Multistage
     exe = "multistage"
     exe_plot = "10multista"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -124,7 +125,7 @@ class MultistageCancer_34(DichotomousCancer):
     model_name = constants.M_MultistageCancer
     exe = "cancer"
     exe_plot = "10cancer"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -205,7 +206,7 @@ class Weibull_217(Dichotomous):
     model_name = constants.M_Weibull
     exe = "weibull"
     exe_plot = "10weibull"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -263,7 +264,7 @@ class LogProbit_34(Dichotomous):
     model_name = constants.M_LogProbit
     exe = "probit"
     exe_plot = "10probit"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -322,7 +323,7 @@ class Probit_34(Dichotomous):
     model_name = constants.M_Probit
     exe = "probit"
     exe_plot = "10probit"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -380,7 +381,7 @@ class Gamma_217(Dichotomous):
     model_name = constants.M_Gamma
     exe = "gamma"
     exe_plot = "10gammhit"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "append_or_overwrite": DefaultParams.append_or_overwrite,
         "smooth_option": DefaultParams.smooth_option,
@@ -437,7 +438,7 @@ class LogLogistic_215(Dichotomous):
     model_name = constants.M_LogLogistic
     exe = "logist"
     exe_plot = "10logist"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "log_transform": DefaultParams.log_transform(d=1),
         "restrict_slope": DefaultParams.restrict(d=1),
@@ -498,7 +499,7 @@ class Logistic_215(Dichotomous):
     model_name = constants.M_Logistic
     exe = "logist"
     exe_plot = "10logist"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "log_transform": DefaultParams.log_transform(d=0),
         "restrict_slope": DefaultParams.restrict(d=0),
@@ -556,7 +557,7 @@ class DichotomousHill_13(Dichotomous):
     exe_plot = "10DichoHill"
     version = 1.3
     date = "02/28/2013"
-    defaults = {
+    defaults: ClassVar = {
         "bmdl_curve_calculation": DefaultParams.bmdl_curve_calculation,
         "restrict_power": DefaultParams.log_transform(d=1),
         "append_or_overwrite": DefaultParams.append_or_overwrite,

--- a/bmds/bmds2/parser.py
+++ b/bmds/bmds2/parser.py
@@ -1,4 +1,5 @@
 import re
+from typing import ClassVar
 
 from .. import constants
 
@@ -22,7 +23,7 @@ class OutputParser:
     re_num = r"[/+/-]?[0-9]+[/.]*[0-9]*[Ee+-]*[0-9]*"
 
     # line-skips by dataset type
-    NUM_LINE_SKIPS_PARAMS = {
+    NUM_LINE_SKIPS_PARAMS: ClassVar = {
         constants.CONTINUOUS: 1,
         constants.CONTINUOUS_INDIVIDUAL: 1,
         constants.DICHOTOMOUS: 1,
@@ -30,14 +31,14 @@ class OutputParser:
         EXPONENTIAL: 4,
     }
 
-    NUM_LINE_SKIPS_FIT = {
+    NUM_LINE_SKIPS_FIT: ClassVar = {
         constants.CONTINUOUS: 3,
         constants.CONTINUOUS_INDIVIDUAL: 3,
         constants.DICHOTOMOUS: 2,
         constants.DICHOTOMOUS_CANCER: 2,
     }
 
-    NUM_LINE_SKIPS_AIC = {
+    NUM_LINE_SKIPS_AIC: ClassVar = {
         constants.CONTINUOUS: 1,
         constants.CONTINUOUS_INDIVIDUAL: 1,
         EXPONENTIAL: 2,

--- a/bmds/bmds2/sessions.py
+++ b/bmds/bmds2/sessions.py
@@ -3,6 +3,7 @@ import os
 import platform
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from typing import ClassVar
 
 import pandas as pd
 from simple_settings import settings
@@ -22,9 +23,9 @@ class BMDS:
     version_str: str = ""
     version_pretty: str = ""
     version_tuple: tuple[int, ...] = ()
-    model_options: dict[str, dict] = {}
+    model_options: ClassVar[dict[str, dict]] = {}
 
-    bmr_options = {
+    bmr_options: ClassVar = {
         constants.DICHOTOMOUS: constants.DICHOTOMOUS_BMRS,
         constants.DICHOTOMOUS_CANCER: constants.DICHOTOMOUS_BMRS,
         constants.CONTINUOUS: constants.CONTINUOUS_BMRS,
@@ -327,7 +328,7 @@ class BMDS_v270(BMDS):
     version_str = constants.BMDS270
     version_pretty = "2.7.0"
     version_tuple = (2, 7, 0)
-    model_options = {
+    model_options: ClassVar = {
         constants.DICHOTOMOUS: {
             constants.M_Logistic: models.Logistic_215,
             constants.M_LogLogistic: models.LogLogistic_215,

--- a/bmds/bmds3/models/base.py
+++ b/bmds/bmds3/models/base.py
@@ -4,7 +4,7 @@ import abc
 import ctypes
 import logging
 import platform
-from typing import TYPE_CHECKING, NamedTuple, Self
+from typing import TYPE_CHECKING, ClassVar, NamedTuple, Self
 
 from pydantic import BaseModel
 
@@ -30,7 +30,7 @@ class BmdsLibraryManager:
     def __init__(self):
         raise RuntimeError("Use as a static-class")
 
-    _dll_cache: dict[str, ctypes.CDLL] = {}
+    _dll_cache: ClassVar[dict[str, ctypes.CDLL]] = {}
 
     @classmethod
     def get_dll(cls, bmds_version: str, base_name: str) -> ctypes.CDLL:

--- a/bmds/bmds3/recommender/checks.py
+++ b/bmds/bmds3/recommender/checks.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Self
+from typing import Any, ClassVar, Self
 
 from pydantic import BaseModel
 
@@ -20,7 +20,7 @@ class CheckResponse(BaseModel):
 
 
 class Check:
-    _enabled_attribute = {
+    _enabled_attribute: ClassVar[dict] = {
         constants.Dtype.DICHOTOMOUS: "enabled_dichotomous",
         constants.Dtype.DICHOTOMOUS_CANCER: "enabled_dichotomous",
         constants.Dtype.CONTINUOUS: "enabled_continuous",

--- a/bmds/bmds3/sessions.py
+++ b/bmds/bmds3/sessions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from copy import copy, deepcopy
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import numpy.typing as npt
@@ -318,7 +318,7 @@ class Bmds330(BmdsSession):
     version_str = constants.BMDS330  # TODO - change
     version_pretty = "3.3.0"
     version_tuple = (3, 3, 0)
-    model_options = {
+    model_options: ClassVar = {
         constants.DICHOTOMOUS: {
             constants.M_Logistic: d3.Logistic,
             constants.M_LogLogistic: d3.LogLogistic,

--- a/bmds/cli/priors_report.py
+++ b/bmds/cli/priors_report.py
@@ -19,7 +19,7 @@ def write_break(f: StringIO):
 
 
 def write_settings(f: StringIO, model: dichotomous.BmdModel, settings: dict):
-    f.write("\n".join(f"* {k}: {repr(v)}" for k, v in settings.items()) + "\n\n")
+    f.write("\n".join(f"* {k}: {v!r}" for k, v in settings.items()) + "\n\n")
     f.write(str(model.settings.priors) + "\n\n")
 
 
@@ -100,20 +100,19 @@ def continuous_priors(f: StringIO):
     write_break(f)
 
     write_model(f, continuous.Linear)
+    # fmt: off
     for settings in [
-        # fmt: off
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal),
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal_ncv),
 
         dict(priors=PriorClass.bayesian),
-        # fmt: on
-    ]:
+    ]:  # fmt: on
         print_c_model(continuous.Linear, settings)
     write_break(f)
 
     write_model(f, continuous.Polynomial)
+    # fmt: off
     for settings in [
-        # fmt: off
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal),
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal_ncv),
 
@@ -123,14 +122,13 @@ def continuous_priors(f: StringIO):
         dict(priors=PriorClass.frequentist_restricted, disttype=DistType.normal_ncv, is_increasing=False),
 
         dict(priors=PriorClass.bayesian),
-        # fmt: on
-    ]:
+    ]:  # fmt: on
         print_c_model(continuous.Polynomial, settings)
     write_break(f)
 
     write_model(f, continuous.Power)
+    # fmt: off
     for settings in [
-        # fmt: off
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal),
         dict(priors=PriorClass.frequentist_unrestricted, disttype=DistType.normal_ncv),
 
@@ -138,8 +136,7 @@ def continuous_priors(f: StringIO):
         dict(priors=PriorClass.frequentist_restricted, disttype=DistType.normal_ncv),
 
         dict(priors=PriorClass.bayesian),
-        # fmt: on
-    ]:
+    ]:  # fmt: on
         print_c_model(continuous.Power, settings)
     write_break(f)
 

--- a/bmds/session.py
+++ b/bmds/session.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, ClassVar
 
 from . import constants
 from .bmds2.sessions import BMDS_v270
@@ -11,11 +11,11 @@ class BMDS:
     A single dataset, related models, outputs, and model recommendations.
     """
 
-    _BMDS_VERSIONS: dict[str, Any] = {
+    _BMDS_VERSIONS: ClassVar[dict[str, Any]] = {
         constants.BMDS270: BMDS_v270,
         constants.BMDS330: Bmds330,
     }
-    _MULTITUMOR_VERSIONS: dict[str, Any] = {
+    _MULTITUMOR_VERSIONS: ClassVar[dict[str, Any]] = {
         constants.BMDS330: Multitumor330,
     }
 

--- a/make.bat
+++ b/make.bat
@@ -17,11 +17,11 @@ echo.  dist         builds source and wheel package
 goto :eof
 
 :lint
-black . --check && ruff .
+ruff format . --check && ruff .
 goto :eof
 
 :format
-black . && ruff . --fix --show-fixes
+ruff format . && ruff . --fix --show-fixes
 goto :eof
 
 :test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-line-length = 100
-target-version = ['py311']
-extend-exclude = '(notebooks/private)'
-
 [tool.coverage.run]
 omit = [
     "./tests/*",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,8 +7,7 @@ pytest-mpl==0.16.1
 coverage==7.3.0
 
 # lint and formatting tools
-black==23.3.0
-ruff==0.0.261
+ruff~=0.1.3
 
 # install bmds in editable mode
 -e .

--- a/tests/bmds3/models/test_continuous.py
+++ b/tests/bmds3/models/test_continuous.py
@@ -12,8 +12,8 @@ from bmds.exceptions import ConfigurationException
 
 class TestPriorOverrides:
     def test_poly(self, cdataset2, negative_cdataset):
+        # fmt: off
         for settings, priors in [
-            # fmt: off
             ({"disttype": DistType.normal, "is_increasing": True}, (0, 1e6)),
             ({"disttype": DistType.normal, "is_increasing": False}, (-1e6, 0)),
             ({"disttype": DistType.normal_ncv, "is_increasing": True}, (0, 18)),
@@ -22,8 +22,7 @@ class TestPriorOverrides:
             ({"disttype": DistType.normal, "priors": PriorClass.frequentist_unrestricted, "is_increasing": False}, (-1e6, 1e6)),
             ({"disttype": DistType.normal_ncv, "priors": PriorClass.frequentist_unrestricted, "is_increasing": True}, (-18, 18)),
             ({"disttype": DistType.normal_ncv, "priors": PriorClass.frequentist_unrestricted, "is_increasing": False}, (-18, 18)),
-            # fmt: on
-        ]:
+        ]:  # fmt: on
             model = continuous.Polynomial(cdataset2, settings)
             beta1 = model.settings.priors.get_prior("beta1")
             assert beta1.min_value == priors[0], settings

--- a/tests/bmds3/recommender/test_checks.py
+++ b/tests/bmds3/recommender/test_checks.py
@@ -146,8 +146,8 @@ class TestChecks:
         settings = Rule(
             rule_class=RuleClass.variance_fit, failure_bin=LogicBin.FAILURE, threshold=0.1
         )
+        # fmt: off
         for disttype, pvalues, bin, message in [
-            # fmt: off
             # pass if test 2 > 0.1
             (DistType.normal, [1, 0.09, 1, 1], LogicBin.FAILURE, "Constant variance test failed (Test 2 p-value < 0.1)"),
             (DistType.log_normal, [1, 0.09, 1, 1], LogicBin.FAILURE, "Constant variance test failed (Test 2 p-value < 0.1)"),
@@ -156,8 +156,8 @@ class TestChecks:
             # pass if test 3 > 0.1
             (DistType.normal_ncv, [1, 1, 0.09, 1], LogicBin.FAILURE, "Nonconstant variance test failed (Test 3 p-value < 0.1)"),
             (DistType.normal_ncv, [0, 0, 0.11, 0], LogicBin.NO_CHANGE, ""),
-            # fmt: on
         ]:
+            # fmt: on
             model.settings.disttype = disttype
             model.results.tests.p_values = pvalues
             resp = checks.VarianceFit.check(cdataset, model, settings)


### PR DESCRIPTION
Remove black and use the new [ruff format](https://astral.sh/blog/the-ruff-formatter) command instead. 

This will require modifications to vscode configuration:

```json
"[python]": {
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true,
    "editor.codeActionsOnSave": {
        "source.fixAll": true
    }
}
```