### PR TITLE
remove zenodo.org badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,6 @@ BMDS Python interface
         :target: https://bmds.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://zenodo.org/badge/61229626.svg
-   :target: https://zenodo.org/badge/latestdoi/61229626
-
 This Python package is designed to run the `USEPA BMDS`_ software from a python
 interface. It requires Python3.11+.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,7 +3,6 @@
 [![pypi](https://img.shields.io/pypi/v/bmds.svg)](https://pypi.python.org/pypi/bmds)
 [![actions](https://github.com/shapiromatron/bmds/workflows/CI/badge.svg)](https://github.com/shapiromatron/bmds/actions)
 [![docs](https://readthedocs.org/projects/bmds/badge/?version=latest)](https://bmds.readthedocs.io/en/latest/?badge=latest)
-[![zenodo](https://zenodo.org/badge/61229626.svg)](https://zenodo.org/badge/latestdoi/61229626)
 
 A python package is designed to run the [USEPA BMDS](https://www.epa.gov/bmds) software. It requires Python3.11+.
 


### PR DESCRIPTION
Remove zenodo.org badge; github permissions required to continue minting releases were too extensive.